### PR TITLE
Add function lookup functionality to JIT engine

### DIFF
--- a/src/anydsl_runtime.h
+++ b/src/anydsl_runtime.h
@@ -77,6 +77,8 @@ void    anydsl_execute_graph(int32_t, int32_t);
 #ifdef RUNTIME_ENABLE_JIT
 void  anydsl_link(const char*);
 void* anydsl_compile(const char*, uint32_t, const char*, uint32_t);
+void* anydsl_get_engine(const char*, uint32_t, uint32_t);
+void* anydsl_lookup(void*, const char*);
 #endif
 
 #ifdef __cplusplus

--- a/src/anydsl_runtime.h
+++ b/src/anydsl_runtime.h
@@ -76,9 +76,8 @@ void    anydsl_execute_graph(int32_t, int32_t);
 
 #ifdef RUNTIME_ENABLE_JIT
 void  anydsl_link(const char*);
-void* anydsl_compile(const char*, uint32_t, const char*, uint32_t);
-void* anydsl_get_engine(const char*, uint32_t, uint32_t);
-void* anydsl_lookup(void*, const char*);
+int32_t anydsl_compile(const char*, uint32_t, uint32_t);
+void *anydsl_lookup_function(int32_t, const char*);
 #endif
 
 #ifdef __cplusplus


### PR DESCRIPTION
Currently, when invoking the JIT engine with ```anydsl_compile``` only allows for retrieving a single function pointer. This pull request extends the API so that arbitrarily many functions can be looked up.

Example:

```cpp
auto code = "...code to be comiled...";
void *engine = anydsl_get_engine(code.c_str(), code.size(), 3);

auto fn1 = (void (*)())anydsl_lookup(engine, "function_one");
auto fn2 = (void (*)())anydsl_lookup(engine, "function_two");
```

The ```anydsl_compile``` API remains unaffected for legacy purposes.

If there is anything that needs to be changed, please let me know 👍 