### PR TITLE
Make the hardware for HLS-backend selectable

### DIFF
--- a/cmake/anydsl_runtime-config.cmake.in
+++ b/cmake/anydsl_runtime-config.cmake.in
@@ -172,7 +172,7 @@ function(anydsl_runtime_wrap outfiles)
         COMMAND ${Impala_BIN} ${_impala_platform_files} ${_infiles} ${_impala_flags} -o ${_basepath}
         COMMAND ${PYTHON_BIN} ${AnyDSL_runtime_ROOT_DIR}/post-patcher.py ${_basepath}
         COMMAND ${CMAKE_COMMAND} -D_basename=${_basename} -DLLVM_AS_BIN=${LLVM_AS_BIN} -P ${AnyDSL_runtime_ROOT_DIR}/cmake/check_nvvmir.cmake
-        COMMAND ${CMAKE_COMMAND} -D_basename=${_basename} -P ${AnyDSL_runtime_ROOT_DIR}/cmake/check_hlssrc.cmake
+        COMMAND ${CMAKE_COMMAND} -DHLS_PART=${HLS_PART} -D_basename=${_basename} -P ${AnyDSL_runtime_ROOT_DIR}/cmake/check_hlssrc.cmake
         WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
         DEPENDS ${Impala_BIN} ${PYTHON_BIN} ${AnyDSL_runtime_ROOT_DIR}/post-patcher.py ${_impala_platform_files} ${_infiles} VERBATIM)
 

--- a/cmake/check_hlssrc.cmake
+++ b/cmake/check_hlssrc.cmake
@@ -10,7 +10,7 @@ if(EXISTS ${_basename}.hls)
                                  "add_files ${_basename}_hls.cpp\n"
                                  "add_files -tb ${_basename}_tb.cpp\n"
                                  "open_solution ${_basename}_${kernel}\n"
-                                 "set_part {xc7z020clg484-1}\n"
+                                 "set_part {${HLS_PART}}\n"
                                  "create_clock -period 10 -name default\n"
                                  "csim_design -compiler clang -ldflags {-lrt} -clean\n"
                                  "csynth_design\n"


### PR DESCRIPTION
Currently, the hardware in the HLS backend is fixed to `xc7z020clg484-1`. This pull request aims to change this by making the hardware optional, so one doesn't have to manually edit the TCL-Script generated by `check_hlssrc.cmake`.
Of course, each project using the `hls` backend has to manually add the option then:

```
if(BACKEND STREQUAL "hls")
    if(NOT HLS_PART)
        set(HLS_PART xc7z020clg484-1 CACHE STRING "select the hardware the high level synthesis should use." FORCE)
    endif()
    string(TOLOWER "${HLS_PART}" HLS_PART)
    message(STATUS "Selected hls part: ${HLS_PART}")
else()
    unset(HLS_PART CACHE)
endif()
```