### PR TITLE
detect PTX version based on CUDA driver version

### DIFF
--- a/src/cuda_platform.cpp
+++ b/src/cuda_platform.cpp
@@ -379,24 +379,11 @@ CUfunction CudaPlatform::load_kernel(DeviceId dev, const std::string& file, cons
     return func;
 }
 
-const char* get_ptx_version_flag(int driver_version) {
-    if (driver_version < 8000)
-        error("unsupported driver version");
-
-    // TODO: comment in as they become available with LLVM versions > 8.0.1
-    // if (driver_version >= 10020)
-    //     return "+ptx65";
-    // if (driver_version >= 10010)
-    //     return "+ptx64";
-    if (driver_version >= 10000)
-        return "+ptx63";
-    if (driver_version >= 9020)
-        return "+ptx62";
-    if (driver_version >= 9010)
-        return "+ptx61";
-    if (driver_version >= 9000)
+const char* get_ptx_feature_flag(CUjit_target target_architecture, int driver_version) {
+    // to enable the use of .sync instructions on older devices, make sure to emit at least PTX 6.0 if supported by the driver
+    if (target_architecture < 70 && driver_version >= 9000)
         return "+ptx60";
-    return "+ptx50";
+    return "";
 }
 
 #if CUDA_VERSION < 9000
@@ -424,7 +411,7 @@ std::string get_libdevice_path(CUjit_target) {
 
 #ifdef AnyDSL_runtime_HAS_JIT_SUPPORT
 bool llvm_nvptx_initialized = false;
-static std::string emit_nvptx(const std::string& program, const std::string& libdevice_file, const std::string& cpu, const char* ptx_version_flag, const std::string &filename, int opt) {
+static std::string emit_nvptx(const std::string& program, const std::string& libdevice_file, const std::string& cpu, const char* ptx_feature_flag, const std::string &filename, int opt) {
     if (!llvm_nvptx_initialized) {
         // ANYDSL_LLVM_ARGS="-nvptx-sched4reg -nvptx-fma-level=2 -nvptx-prec-divf32=0 -nvptx-prec-sqrtf32=0 -nvptx-f32ftz=1"
         const char* env_var = std::getenv("ANYDSL_LLVM_ARGS");
@@ -463,7 +450,7 @@ static std::string emit_nvptx(const std::string& program, const std::string& lib
     auto target = llvm::TargetRegistry::lookupTarget(triple_str, error_str);
     llvm::TargetOptions options;
     options.AllowFPOpFusion = llvm::FPOpFusion::Fast;
-    std::unique_ptr<llvm::TargetMachine> machine(target->createTargetMachine(triple_str, cpu, ptx_version_flag /* attrs */, options, llvm::Reloc::PIC_, llvm::CodeModel::Small, llvm::CodeGenOpt::Aggressive));
+    std::unique_ptr<llvm::TargetMachine> machine(target->createTargetMachine(triple_str, cpu, ptx_feature_flag, options, llvm::Reloc::PIC_, llvm::CodeModel::Small, llvm::CodeGenOpt::Aggressive));
 
     // link libdevice
     std::unique_ptr<llvm::Module> libdevice_module(llvm::parseIRFile(libdevice_file, diagnostic_err, llvm_context));
@@ -515,8 +502,8 @@ static std::string emit_nvptx(const std::string&, const std::string&, const std:
 std::string CudaPlatform::compile_nvptx(DeviceId dev, const std::string& filename, const std::string& program_string) const {
     debug("Compiling NVVM to PTX using nvptx for '%' on CUDA device %", filename, dev);
     std::string cpu = "sm_" + std::to_string(devices_[dev].compute_capability);
-    const char* ptx_version_flag = get_ptx_version_flag(devices_[dev].driver_version);
-    return emit_nvptx(program_string, get_libdevice_path(devices_[dev].compute_capability), cpu, ptx_version_flag, filename, 3);
+    const char* ptx_feature_flag = get_ptx_feature_flag(devices_[dev].compute_capability, devices_[dev].driver_version);
+    return emit_nvptx(program_string, get_libdevice_path(devices_[dev].compute_capability), cpu, ptx_feature_flag, filename, 3);
 }
 
 #if CUDA_VERSION < 10000

--- a/src/cuda_platform.h
+++ b/src/cuda_platform.h
@@ -61,6 +61,8 @@ protected:
         std::unordered_map<std::string, CUmodule> modules;
         std::unordered_map<CUmodule, FunctionMap> functions;
 
+        int driver_version;
+
         DeviceData() {}
         DeviceData(const DeviceData&) = delete;
         DeviceData(DeviceData&& data)
@@ -69,6 +71,7 @@ protected:
             , compute_capability(data.compute_capability)
             , modules(std::move(data.modules))
             , functions(std::move(data.functions))
+            , driver_version(data.driver_version)
         {}
 
         void lock() {


### PR DESCRIPTION
By default, LLVM picks the PTX version to emit to be the minimum version of PTX that supports the target architecture. However, CUDA 9.0 introduced a new PTX version with new instructions that also target older hardware (e.g., `.sync` versions of existing primitives such as warp votes and shuffles). Some of these new instructions replace old instructions; use of these old instructions is deprecated even on old hardware.

Thus, on newer versions of CUDA, targeting older compute capabilities requires PTX versions more recent than what LLVM picks by default. For example, using `shfl.sync` when targeting a Pascal GPU would cause the generated PTX to fail JIT compilation because LLVM 8.0.1 picks PTX 5.0 for sm_61 while 6.0 would be required for `shfl.sync` to be available.

PTX is generated for consumption by the driver. Since we know at runtime which driver we're dealing with, we can simply pick the PTX version based on the latest version of CUDA supported by the driver. Newer versions of PTX should always be able to target older hardware (down to whatever is the oldest architecture supported by the driver) and instructions used are checked against the target architecture rather than PTX version. Thus, I would argue that this approach would be the most adequate way to fix this problem for the runtime…