### PR TITLE
replace use of deprecated ${CMAKE_CFG_INTDIR}

### DIFF
--- a/cmake/anydsl_runtime-config.cmake.in
+++ b/cmake/anydsl_runtime-config.cmake.in
@@ -267,7 +267,7 @@ function(anydsl_runtime_wrap outfiles)
         set(_basename ${PARGS_NAME})
     endif()
 
-    set(_basepath ${CMAKE_CURRENT_BINARY_DIR}/${CMAKE_CFG_INTDIR}/${_basename})
+    set(_basepath ${CMAKE_CURRENT_BINARY_DIR}/$<CONFIG>/${_basename})
     set(_llfile ${_basepath}.ll)
     set(_cfile ${_basepath}.c)
     set(_objfile ${_basepath}.o)


### PR DESCRIPTION
results in build errors when using the `Ninja Multi-Config` generator. replaced with `$<CONFIG>` generator expression as per suggestion in the [docs](https://cmake.org/cmake/help/v3.21/variable/CMAKE_CFG_INTDIR.html).