### PR TITLE
Add option to specify module name for JIT

### DIFF
--- a/src/anydsl_jit.h
+++ b/src/anydsl_jit.h
@@ -13,6 +13,7 @@ AnyDSL_runtime_API Runtime& runtime();
 AnyDSL_runtime_jit_API void anydsl_link(const char*);
 AnyDSL_runtime_jit_API int32_t anydsl_compile(const char*, uint32_t, uint32_t);
 AnyDSL_runtime_jit_API void *anydsl_lookup_function(int32_t, const char*);
+AnyDSL_runtime_jit_API void anydsl_jit_set_module_name(const char*);
 #endif
 
 #endif


### PR DESCRIPTION
Adding the new API function `anydsl_jit_set_module_name(const char*)` to make it possible to specify (internal) module name of all future calls to `anydsl_compile`.

This is necessary for modules containing CUDA kernels, whose symbols disappear after subsequent calls to `anydsl_compile`. The error `Driver API function cuModuleGetFunction() (500) [file ../src/cuda_platform.cpp, line 336]: CUDA_ERROR_NOT_FOUND: named symbol not found` is raised (using the artic JIT). That above behavior might actually be a bug, but introducing the option to set the (internal) module name might be beneficial in the future nevertheless.

A different approach would be to completely rework the JIT interface allowing multiple JIT instances, instead of one singleton JIT class.

Note: The default behavior is still intact. Using the new function is **not** mandatory.