### PR TITLE
Add flag to turn debug output on and off independently of assertions

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -9,6 +9,7 @@ set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
 option(BUILD_SHARED_LIBS "Build shared libraries" ON)
 option(RUNTIME_JIT "enable jit support in the runtime" OFF)
+option(DEBUG_OUTPUT "enable debug output" OFF)
 
 if(CMAKE_BUILD_TYPE STREQUAL "")
     set(CMAKE_BUILD_TYPE Debug CACHE STRING "Debug or Release" FORCE)
@@ -22,6 +23,8 @@ set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/bin)
 
 find_path(Artic_DIR NAMES artic-config.cmake PATHS ${Artic_DIR} $ENV{Artic_DIR} ${CMAKE_BINARY_DIR}/share/anydsl/cmake)
 find_path(Impala_DIR NAMES impala-config.cmake PATHS ${Impala_DIR} $ENV{Impala_DIR} ${CMAKE_BINARY_DIR}/share/anydsl/cmake)
+
+set(AnyDSL_runtime_ENABLE_DEBUG_OUTPUT ${DEBUG_OUTPUT})
 
 add_subdirectory(src)
 

--- a/src/anydsl_runtime_config.h.in
+++ b/src/anydsl_runtime_config.h.in
@@ -53,4 +53,9 @@
 #define AnyDSL_runtime_SOURCE_DIR           "@CMAKE_CURRENT_SOURCE_DIR@"
 
 
+// debug output
+
+#cmakedefine AnyDSL_runtime_ENABLE_DEBUG_OUTPUT
+
+
 #endif // ANYDSL_RUNTIME_CONFIG_H

--- a/src/log.h
+++ b/src/log.h
@@ -38,7 +38,7 @@ void info(Args... args) {
 
 template <typename... Args>
 void debug(Args... args) {
-#ifndef NDEBUG
+#ifdef AnyDSL_runtime_ENABLE_DEBUG_OUTPUT
     print(std::cout, args...);
 #else
     unused(args...);


### PR DESCRIPTION
Assertions and debug output are semantically different things. One might want to compile with assertions on but no debug output or vice versa. This change adds a new flag `AnyDSL_runtime_ENABLE_DEBUG_OUTPUT` to allow for controlling whether the runtime outputs debug output separately from whether `NDEBUG` is defined.