### PR TITLE
Add get_nano_time() function

### DIFF
--- a/platforms/artic/runtime.impala
+++ b/platforms/artic/runtime.impala
@@ -14,6 +14,7 @@
 #[import(cc = "C", name = "anydsl_random_val_u64")] fn random_val_u64() -> u64;
 
 #[import(cc = "C", name = "anydsl_get_micro_time")]  fn get_micro_time() -> i64;
+#[import(cc = "C", name = "anydsl_get_nano_time")]  fn get_nano_time() -> i64;
 #[import(cc = "C", name = "anydsl_get_kernel_time")] fn get_kernel_time() -> i64;
 
 #[import(cc = "C", name = "anydsl_print_i16")]    fn print_i16(_: i16) -> ();

--- a/platforms/artic/runtime.impala
+++ b/platforms/artic/runtime.impala
@@ -14,7 +14,7 @@
 #[import(cc = "C", name = "anydsl_random_val_u64")] fn random_val_u64() -> u64;
 
 #[import(cc = "C", name = "anydsl_get_micro_time")]  fn get_micro_time() -> i64;
-#[import(cc = "C", name = "anydsl_get_nano_time")]  fn get_nano_time() -> i64;
+#[import(cc = "C", name = "anydsl_get_nano_time")]   fn get_nano_time() -> i64;
 #[import(cc = "C", name = "anydsl_get_kernel_time")] fn get_kernel_time() -> i64;
 
 #[import(cc = "C", name = "anydsl_print_i16")]    fn print_i16(_: i16) -> ();

--- a/platforms/impala/runtime.impala
+++ b/platforms/impala/runtime.impala
@@ -16,6 +16,7 @@ extern "C" {
     fn "anydsl_random_val_u64"  random_val_u64() -> u64;
 
     fn "anydsl_get_micro_time"  get_micro_time() -> i64;
+    fn "anydsl_get_nano_time"  get_nano_time() -> i64;
     fn "anydsl_get_kernel_time" get_kernel_time() -> i64;
 
     fn "anydsl_print_i16"    print_i16(i16) -> ();

--- a/platforms/impala/runtime.impala
+++ b/platforms/impala/runtime.impala
@@ -16,7 +16,7 @@ extern "C" {
     fn "anydsl_random_val_u64"  random_val_u64() -> u64;
 
     fn "anydsl_get_micro_time"  get_micro_time() -> i64;
-    fn "anydsl_get_nano_time"  get_nano_time() -> i64;
+    fn "anydsl_get_nano_time"   get_nano_time() -> i64;
     fn "anydsl_get_kernel_time" get_kernel_time() -> i64;
 
     fn "anydsl_print_i16"    print_i16(i16) -> ();

--- a/src/anydsl_runtime.cpp
+++ b/src/anydsl_runtime.cpp
@@ -139,7 +139,12 @@ void anydsl_synchronize(int32_t mask) {
 
 uint64_t anydsl_get_micro_time() {
     using namespace std::chrono;
-    return duration_cast<microseconds>(high_resolution_clock::now().time_since_epoch()).count();
+    return duration_cast<microseconds>(steady_clock::now().time_since_epoch()).count();
+}
+
+uint64_t anydsl_get_nano_time() {
+    using namespace std::chrono;
+    return duration_cast<nanoseconds>(steady_clock::now().time_since_epoch()).count();
 }
 
 uint64_t anydsl_get_kernel_time() {

--- a/src/anydsl_runtime.h
+++ b/src/anydsl_runtime.h
@@ -44,6 +44,7 @@ AnyDSL_runtime_API float    anydsl_random_val_f32();
 AnyDSL_runtime_API uint64_t anydsl_random_val_u64();
 
 AnyDSL_runtime_API uint64_t anydsl_get_micro_time();
+AnyDSL_runtime_API uint64_t anydsl_get_nano_time();
 AnyDSL_runtime_API uint64_t anydsl_get_kernel_time();
 
 AnyDSL_runtime_API int32_t anydsl_isinff(float);


### PR DESCRIPTION
Needed for more precise timing in anyq. Switched both `get_micro_time()` and `get_nano_time()` to use `std::chrono::steady_clock` since timestamps are generally required to be monotonic which `std::high_resolution_clock` is not guaranteed to be (and on pretty much all relevant implementations, `std::steady_clock` should have the same resolution as `std::high_resolution_clock` anyways).