### PR TITLE
Add generated .cu files as byproducts in anydsl_runtime_wrap

### DIFF
--- a/cmake/anydsl_runtime-config.cmake.in
+++ b/cmake/anydsl_runtime-config.cmake.in
@@ -258,6 +258,7 @@ function(anydsl_runtime_wrap outfiles)
     set(_basepath ${CMAKE_CURRENT_BINARY_DIR}/${CMAKE_CFG_INTDIR}/${_basename})
     set(_llfile ${_basepath}.ll)
     set(_cfile ${_basepath}.c)
+    set(_cufile ${_basepath}.cu)
     set(_objfile ${_basepath}.o)
 
     set(_frontend_platform_files
@@ -279,7 +280,7 @@ function(anydsl_runtime_wrap outfiles)
 
     if(PARGS_EMIT_C)
         # generate .c file
-        add_custom_command(OUTPUT ${_cfile}
+        add_custom_command(OUTPUT ${_cfile} BYPRODUCTS ${_cufile}
             COMMAND ${_frontend_bin} ${_frontend_platform_files} ${_infiles} ${_frontend_flags} --emit-c -o ${_basepath}
             WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
             DEPENDS ${_frontend_bin} ${_frontend_platform_files} ${_infiles} VERBATIM COMMAND_EXPAND_LISTS)
@@ -289,7 +290,7 @@ function(anydsl_runtime_wrap outfiles)
             DEPENDS ${_cfile} VERBATIM COMMAND_EXPAND_LISTS)
     else()
         # generate .ll file and patch it
-        add_custom_command(OUTPUT ${_llfile}
+        add_custom_command(OUTPUT ${_llfile} BYPRODUCTS ${_cufile}
             COMMAND ${_frontend_bin} ${_frontend_platform_files} ${_infiles} ${_frontend_flags} --emit-llvm -o ${_basepath}
             COMMAND ${Python3_EXECUTABLE} ${AnyDSL_runtime_ROOT_DIR}/post-patcher.py ${_basepath}
             COMMAND ${CMAKE_COMMAND} -D_basename=${_basename} -DLLVM_AS_BIN=${LLVM_AS_BIN} -P ${AnyDSL_runtime_ROOT_DIR}/cmake/check_nvvmir.cmake


### PR DESCRIPTION
Necessary for dependencies of custom commands that further down the line may be dealing with these files to be resolved correctly.

I think adding them as byproducts should be fine even when targeting platforms where no .cu files will be generated?