### PR TITLE
Modern CUDA toolkit search

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -27,40 +27,69 @@ add_library(runtime_base STATIC
     log.h)
 
 # look for CUDA
-find_package(CUDA QUIET)
-if(CUDA_FOUND)
-    find_library(CUDA_NVVM_LIBRARY nvvm
-        HINTS ${CUDA_TOOLKIT_ROOT_DIR}/nvvm
-        PATH_SUFFIXES lib lib64 lib/x64)
-    find_library(CUDA_NVRTC_LIBRARY nvrtc
-        HINTS ${CUDA_TOOLKIT_ROOT_DIR}
-        PATH_SUFFIXES lib lib64 lib/x64)
-    if(CUDA_NVRTC_LIBRARY)
-        set(AnyDSL_runtime_CUDA_NVRTC TRUE)
-    else()
-        set(CUDA_NVRTC_LIBRARY "")
+if(${CMAKE_VERSION} VERSION_LESS "3.17.0")
+    find_package(CUDA QUIET)
+    if(CUDA_FOUND)
+        find_library(CUDA_NVVM_LIBRARY nvvm
+            HINTS ${CUDA_TOOLKIT_ROOT_DIR}/nvvm
+            PATH_SUFFIXES lib lib64 lib/x64)
+        find_library(CUDA_NVRTC_LIBRARY nvrtc
+            HINTS ${CUDA_TOOLKIT_ROOT_DIR}
+            PATH_SUFFIXES lib lib64 lib/x64)
+        if(CUDA_NVRTC_LIBRARY)
+            set(AnyDSL_runtime_CUDA_NVRTC TRUE)
+        else()
+            set(CUDA_NVRTC_LIBRARY "")
+        endif()
+        find_library(CUDA_LIBRARY cuda
+            HINTS ${CUDA_TOOLKIT_ROOT_DIR}
+            PATH_SUFFIXES lib lib64 lib/x64)
+        add_library(runtime_cuda STATIC cuda_platform.cpp cuda_platform.h)
+        target_include_directories(runtime_cuda PRIVATE ${CUDA_INCLUDE_DIRS} "${CUDA_TOOLKIT_ROOT_DIR}/nvvm/include")
+        target_link_libraries(runtime_cuda PRIVATE runtime_base ${CUDA_LIBRARY} ${CUDA_NVVM_LIBRARY} ${CUDA_NVRTC_LIBRARY})
+        list(APPEND RUNTIME_PLATFORMS runtime_cuda)
+        # TODO: would be nice to reference directly the file
+        find_path(AnyDSL_runtime_LIBDEVICE_DIR
+            NAMES libdevice.10.bc libdevice.compute_50.10.bc libdevice.compute_35.10.bc libdevice.compute_30.10.bc libdevice.compute_20.10.bc
+            HINTS ${CUDA_TOOLKIT_ROOT_DIR}
+            PATH_SUFFIXES nvvm/libdevice)
+        find_program(AnyDSL_runtime_NVCC_BIN nvcc
+            HINTS ${CUDA_NVCC_EXECUTABLE} ${CUDA_TOOLKIT_ROOT_DIR}
+            PATH_SUFFIXES bin)
+        find_path(AnyDSL_runtime_NVCC_INC NAMES cuda.h nvrtc.h
+            HINTS ${CUDA_INCLUDE_DIRS} ${CUDA_TOOLKIT_INCLUDE} ${CUDA_TOOLKIT_ROOT_DIR}
+            PATH_SUFFIXES include)
+        mark_as_advanced(AnyDSL_runtime_LIBDEVICE_DIR AnyDSL_runtime_NVCC_BIN AnyDSL_runtime_NVCC_INC)
     endif()
-    find_library(CUDA_LIBRARY cuda
-        HINTS ${CUDA_TOOLKIT_ROOT_DIR}
-        PATH_SUFFIXES lib lib64 lib/x64)
-    add_library(runtime_cuda STATIC cuda_platform.cpp cuda_platform.h)
-    target_include_directories(runtime_cuda PRIVATE ${CUDA_INCLUDE_DIRS} "${CUDA_TOOLKIT_ROOT_DIR}/nvvm/include")
-    target_link_libraries(runtime_cuda PRIVATE runtime_base ${CUDA_LIBRARY} ${CUDA_NVVM_LIBRARY} ${CUDA_NVRTC_LIBRARY})
-    list(APPEND RUNTIME_PLATFORMS runtime_cuda)
-    # TODO: would be nice to reference directly the file
-    find_path(AnyDSL_runtime_LIBDEVICE_DIR
-        NAMES libdevice.10.bc libdevice.compute_50.10.bc libdevice.compute_35.10.bc libdevice.compute_30.10.bc libdevice.compute_20.10.bc
-        HINTS ${CUDA_TOOLKIT_ROOT_DIR}
-        PATH_SUFFIXES nvvm/libdevice)
-    find_program(AnyDSL_runtime_NVCC_BIN nvcc
-        HINTS ${CUDA_NVCC_EXECUTABLE} ${CUDA_TOOLKIT_ROOT_DIR}
-        PATH_SUFFIXES bin)
-    find_path(AnyDSL_runtime_NVCC_INC NAMES cuda.h nvrtc.h
-        HINTS ${CUDA_INCLUDE_DIRS} ${CUDA_TOOLKIT_INCLUDE} ${CUDA_TOOLKIT_ROOT_DIR}
-        PATH_SUFFIXES include)
-    mark_as_advanced(AnyDSL_runtime_LIBDEVICE_DIR AnyDSL_runtime_NVCC_BIN AnyDSL_runtime_NVCC_INC)
+    set(AnyDSL_runtime_HAS_CUDA_SUPPORT ${CUDA_FOUND} CACHE INTERNAL "enables CUDA/NVVM support")
+else()
+    find_package(CUDAToolkit QUIET)
+    if(CUDAToolkit_FOUND)
+        if(NOT CUDAToolkit_LIBRARY_ROOT)
+            set(CUDAToolkit_LIBRARY_ROOT ${CUDAToolkit_BIN_DIR}/../)
+        endif()
+        find_library(CUDA_NVVM_LIBRARY nvvm
+            HINTS ${CUDAToolkit_LIBRARY_ROOT}/nvvm
+            PATH_SUFFIXES lib lib64 lib/x64)
+        add_library(runtime_cuda STATIC cuda_platform.cpp cuda_platform.h)
+        target_include_directories(runtime_cuda PRIVATE "${CUDAToolkit_LIBRARY_ROOT}/nvvm/include")
+        target_link_libraries(runtime_cuda PRIVATE runtime_base CUDA::cudart CUDA::cuda_driver CUDA::nvrtc ${CUDA_NVVM_LIBRARY})
+        list(APPEND RUNTIME_PLATFORMS runtime_cuda)
+        # TODO: would be nice to reference directly the file
+        find_path(AnyDSL_runtime_LIBDEVICE_DIR
+            NAMES libdevice.10.bc libdevice.compute_50.10.bc libdevice.compute_35.10.bc libdevice.compute_30.10.bc libdevice.compute_20.10.bc
+            HINTS ${CUDA_TOOLKIT_ROOT_DIR} ${CUDAToolkit_LIBRARY_ROOT} ${CUDAToolkit_LIBRARY_DIR}
+            PATH_SUFFIXES nvvm/libdevice)
+        find_program(AnyDSL_runtime_NVCC_BIN nvcc
+            HINTS ${CUDA_NVCC_EXECUTABLE} ${CUDA_TOOLKIT_ROOT_DIR} ${CUDAToolkit_NVCC_EXECUTABLE} ${CUDAToolkit_BIN_DIR}
+            PATH_SUFFIXES bin)
+        find_path(AnyDSL_runtime_NVCC_INC NAMES cuda.h nvrtc.h
+            HINTS ${CUDA_INCLUDE_DIRS} ${CUDA_TOOLKIT_INCLUDE} ${CUDA_TOOLKIT_ROOT_DIR} ${CUDAToolkit_INCLUDE_DIRS}
+            PATH_SUFFIXES include)
+        mark_as_advanced(AnyDSL_runtime_LIBDEVICE_DIR AnyDSL_runtime_NVCC_BIN AnyDSL_runtime_NVCC_INC)
+    endif()
+    set(AnyDSL_runtime_HAS_CUDA_SUPPORT ${CUDAToolkit_FOUND} CACHE INTERNAL "enables CUDA/NVVM support")
 endif()
-set(AnyDSL_runtime_HAS_CUDA_SUPPORT ${CUDA_FOUND} CACHE INTERNAL "enables CUDA/NVVM support")
 
 # look for OpenCL
 find_package(OpenCL)


### PR DESCRIPTION
Uses modern FindCUDAToolkit for CMake +3.17.
Necessary to get rid of the deprecated CUDA_LIBRARY cmake variable. It is not defined on some systems as libcuda.so is not on the directory it used to be some years ago.
