### PR TITLE
Add optional log level to c jit api

### DIFF
--- a/src/anydsl_jit.h
+++ b/src/anydsl_jit.h
@@ -12,8 +12,8 @@ AnyDSL_runtime_API Runtime& runtime();
 #ifdef AnyDSL_runtime_HAS_JIT_SUPPORT
 AnyDSL_runtime_jit_API void anydsl_link(const char*);
 AnyDSL_runtime_jit_API int32_t anydsl_compile(const char*, uint32_t, uint32_t);
-AnyDSL_runtime_jit_API int32_t anydsl_compile2(const char*, uint32_t, uint32_t, uint32_t /* log level (4=error only, 3=warn, 2=info, 1=verbose, 0=debug) */);
 AnyDSL_runtime_jit_API void *anydsl_lookup_function(int32_t, const char*);
+AnyDSL_runtime_jit_API void anydsl_set_log_level(uint32_t /* log level (4=error only, 3=warn, 2=info, 1=verbose, 0=debug) */);
 #endif
 
 #endif

--- a/src/anydsl_jit.h
+++ b/src/anydsl_jit.h
@@ -12,6 +12,7 @@ AnyDSL_runtime_API Runtime& runtime();
 #ifdef AnyDSL_runtime_HAS_JIT_SUPPORT
 AnyDSL_runtime_jit_API void anydsl_link(const char*);
 AnyDSL_runtime_jit_API int32_t anydsl_compile(const char*, uint32_t, uint32_t);
+AnyDSL_runtime_jit_API int32_t anydsl_compile2(const char*, uint32_t, uint32_t, uint32_t /* log level (0=error only, 1=warn, 2=info, 3=verbose, 4=debug) */);
 AnyDSL_runtime_jit_API void *anydsl_lookup_function(int32_t, const char*);
 #endif
 

--- a/src/anydsl_jit.h
+++ b/src/anydsl_jit.h
@@ -12,7 +12,7 @@ AnyDSL_runtime_API Runtime& runtime();
 #ifdef AnyDSL_runtime_HAS_JIT_SUPPORT
 AnyDSL_runtime_jit_API void anydsl_link(const char*);
 AnyDSL_runtime_jit_API int32_t anydsl_compile(const char*, uint32_t, uint32_t);
-AnyDSL_runtime_jit_API int32_t anydsl_compile2(const char*, uint32_t, uint32_t, uint32_t /* log level (0=error only, 1=warn, 2=info, 3=verbose, 4=debug) */);
+AnyDSL_runtime_jit_API int32_t anydsl_compile2(const char*, uint32_t, uint32_t, uint32_t /* log level (4=error only, 3=warn, 2=info, 1=verbose, 0=debug) */);
 AnyDSL_runtime_jit_API void *anydsl_lookup_function(int32_t, const char*);
 #endif
 

--- a/src/jit.cpp
+++ b/src/jit.cpp
@@ -40,13 +40,14 @@ struct JIT {
 
     std::vector<Program> programs;
     Runtime* runtime;
+    thorin::LogLevel log_level;
 
-    JIT(Runtime* runtime) : runtime(runtime) {
+    JIT(Runtime* runtime) : runtime(runtime), log_level(thorin::LogLevel::Warn) {
         llvm::InitializeNativeTarget();
         llvm::InitializeNativeTargetAsmPrinter();
     }
 
-    int32_t compile(const char* program_src, uint32_t size, uint32_t opt, thorin::LogLevel log_level) {
+    int32_t compile(const char* program_src, uint32_t size, uint32_t opt) {
         // The LLVM context and module have to be alive for the duration of this function
         std::unique_ptr<llvm::LLVMContext> llvm_context;
         std::unique_ptr<llvm::Module> llvm_module;
@@ -150,11 +151,11 @@ void anydsl_link(const char* lib) {
 }
 
 int32_t anydsl_compile(const char* program, uint32_t size, uint32_t opt) {
-    return jit().compile(program, size, opt, thorin::LogLevel::Warn);
+    return jit().compile(program, size, opt);
 }
 
-int32_t anydsl_compile2(const char* program, uint32_t size, uint32_t opt, uint32_t log_level) {
-    return jit().compile(program, size, opt, log_level <= 4 ? static_cast<thorin::LogLevel>(log_level) : thorin::LogLevel::Warn);
+void anydsl_set_log_level(uint32_t log_level) {
+    jit().log_level = log_level <= 4 ? static_cast<thorin::LogLevel>(log_level) : thorin::LogLevel::Warn;
 }
 
 void* anydsl_lookup_function(int32_t key, const char* fn_name) {

--- a/src/jit.cpp
+++ b/src/jit.cpp
@@ -154,26 +154,7 @@ int32_t anydsl_compile(const char* program, uint32_t size, uint32_t opt) {
 }
 
 int32_t anydsl_compile2(const char* program, uint32_t size, uint32_t opt, uint32_t loglevel) {
-    thorin::LogLevel level = thorin::LogLevel::Warn;
-    switch(loglevel) {
-        case 0:
-        level = thorin::LogLevel::Error;
-        break;
-    default:
-    case 1:
-        level = thorin::LogLevel::Warn;
-        break;
-    case 2:
-        level = thorin::LogLevel::Info;
-        break;
-    case 3:
-        level = thorin::LogLevel::Verbose;
-        break;
-    case 4:
-        level = thorin::LogLevel::Debug;
-        break;
-    }
-    return jit().compile(program, size, opt, level);
+    return jit().compile(program, size, opt, loglevel <= 4 ? static_cast<thorin::LogLevel>(loglevel) : thorin::LogLevel::Warn);
 }
 
 void* anydsl_lookup_function(int32_t key, const char* fn_name) {

--- a/src/jit.cpp
+++ b/src/jit.cpp
@@ -46,7 +46,7 @@ struct JIT {
         llvm::InitializeNativeTargetAsmPrinter();
     }
 
-    int32_t compile(const char* program_src, uint32_t size, uint32_t opt, thorin::LogLevel logLevel) {
+    int32_t compile(const char* program_src, uint32_t size, uint32_t opt, thorin::LogLevel log_level) {
         // The LLVM context and module have to be alive for the duration of this function
         std::unique_ptr<llvm::LLVMContext> llvm_context;
         std::unique_ptr<llvm::Module> llvm_module;
@@ -62,7 +62,7 @@ struct JIT {
             assert(opt <= 3);
 
             thorin::World world(module_name);
-            world.set(logLevel);
+            world.set(log_level);
             world.set(std::make_shared<thorin::Stream>(std::cerr));
             if (!::compile(
                 { "runtime", module_name },
@@ -153,8 +153,8 @@ int32_t anydsl_compile(const char* program, uint32_t size, uint32_t opt) {
     return jit().compile(program, size, opt, thorin::LogLevel::Warn);
 }
 
-int32_t anydsl_compile2(const char* program, uint32_t size, uint32_t opt, uint32_t loglevel) {
-    return jit().compile(program, size, opt, loglevel <= 4 ? static_cast<thorin::LogLevel>(loglevel) : thorin::LogLevel::Warn);
+int32_t anydsl_compile2(const char* program, uint32_t size, uint32_t opt, uint32_t log_level) {
+    return jit().compile(program, size, opt, log_level <= 4 ? static_cast<thorin::LogLevel>(log_level) : thorin::LogLevel::Warn);
 }
 
 void* anydsl_lookup_function(int32_t key, const char* fn_name) {


### PR DESCRIPTION
Please add this simple `anydsl_jit_compile2` version to finally get rid of warnings, which should not be warnings (for end users) like:

`W::4294967295: argument '_258880' of aggregate type 'struct SceneDatabase' contains pointer (not supported in OpenCL 1.2)`

or

`W:jit_9014cfb3ce461cae:3548 col 37 - 52: slow: alloca and loads/stores needed for aggregate '_257943'`

The latter might be important, but only for developers (who can change the code). In [Ignis](https://github.com/PearCoding/Ignis) these warnings will only be enabled in verbose mode, for example.

It is just an additional function. Primarily cosmetic. No existing projects should change in behavior. 