### PR TITLE
Add missing math intrinsics to jit (artic)

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -158,6 +158,13 @@ if(RUNTIME_JIT)
             ../platforms/${frontend}/intrinsics.impala
             ../platforms/${frontend}/runtime.impala)
 
+        # Add artic-only math intrinsics
+        if("${frontend}" STREQUAL "artic")
+            set(RUNTIME_FRONTEND_SRCS
+                ${RUNTIME_FRONTEND_SRCS}
+                ../platforms/${frontend}/intrinsics_math.impala)
+        endif()
+
         set(RUNTIME_JIT_SRC jit.cpp)
         set(RUNTIME_SOURCES_FRONTEND_INC_FILE ${CMAKE_CURRENT_BINARY_DIR}/${frontend}/runtime_srcs.inc)
         add_custom_command(OUTPUT ${RUNTIME_SOURCES_FRONTEND_INC_FILE}


### PR DESCRIPTION
Artic has additional platform specific intrinsics for math.
The additional file `intrinsics_math.impala` is already added in the cmake configs, but not in the jit embedded source.
The PR exactly adds the missing piece. 