### PR TITLE
Add anydsl_device_check_feature_support

### DIFF
--- a/platforms/artic/runtime.impala
+++ b/platforms/artic/runtime.impala
@@ -1,5 +1,7 @@
-#[import(cc = "C", name = "anydsl_info")]           fn runtime_info() -> ();
-#[import(cc = "C", name = "anydsl_device_name")]    fn runtime_device_name(_device: i32) -> &[u8];
+#[import(cc = "C", name = "anydsl_info")]                         fn runtime_info() -> ();
+#[import(cc = "C", name = "anydsl_device_name")]                  fn runtime_device_name(_device: i32) -> &[u8];
+#[import(cc = "C", name = "anydsl_device_check_feature_support")] fn runtime_device_check_feature_support(_device: i32, _feature: &[u8]) -> bool;
+
 #[import(cc = "C", name = "anydsl_alloc")]          fn runtime_alloc(_device: i32, _size: i64) -> &mut [i8];
 #[import(cc = "C", name = "anydsl_alloc_host")]     fn runtime_alloc_host(_device: i32, _size: i64) -> &mut [i8];
 #[import(cc = "C", name = "anydsl_alloc_unified")]  fn runtime_alloc_unified(_device: i32, _size: i64) -> &mut [i8];

--- a/platforms/impala/runtime.impala
+++ b/platforms/impala/runtime.impala
@@ -1,6 +1,7 @@
 extern "C" {
-    fn "anydsl_info"           runtime_info() -> ();
-    fn "anydsl_device_name"    runtime_device_name(_device: i32) -> &[u8];
+    fn "anydsl_info"                         runtime_info() -> ();
+    fn "anydsl_device_name"                  runtime_device_name(_device: i32) -> &[u8];
+    fn "anydsl_device_check_feature_support" runtime_device_check_feature_support(_device: i32, _feature: &[u8]) -> bool;
 
     fn "anydsl_alloc"          runtime_alloc(i32, i64) -> &[i8];
     fn "anydsl_alloc_host"     runtime_alloc_host(i32, i64) -> &[i8];

--- a/src/anydsl_runtime.cpp
+++ b/src/anydsl_runtime.cpp
@@ -78,6 +78,10 @@ const char* anydsl_device_name(int32_t mask) {
     return runtime().device_name(to_platform(mask), to_device(mask));
 }
 
+bool anydsl_device_check_feature_support(int32_t mask, const char* feature) {
+    return runtime().device_check_feature_support(to_platform(mask), to_device(mask), feature);
+}
+
 void* anydsl_alloc(int32_t mask, int64_t size) {
     return runtime().alloc(to_platform(mask), to_device(mask), size);
 }

--- a/src/anydsl_runtime.h
+++ b/src/anydsl_runtime.h
@@ -22,6 +22,7 @@ enum {
 AnyDSL_runtime_API void anydsl_info(void);
 
 AnyDSL_runtime_API const char* anydsl_device_name(int32_t);
+AnyDSL_runtime_API bool anydsl_device_check_feature_support(int32_t, const char*);
 
 AnyDSL_runtime_API void* anydsl_alloc(int32_t, int64_t);
 AnyDSL_runtime_API void* anydsl_alloc_host(int32_t, int64_t);

--- a/src/cpu_platform.h
+++ b/src/cpu_platform.h
@@ -67,6 +67,7 @@ protected:
     size_t dev_count() const override { return 1; }
     std::string name() const override { return "CPU"; }
     const char* device_name(DeviceId) const override { return device_name_.c_str(); }
+    bool device_check_feature_support(DeviceId, const char*) const override { return false; }
 };
 
 #endif

--- a/src/cuda_platform.cpp
+++ b/src/cuda_platform.cpp
@@ -9,6 +9,7 @@
 #include <filesystem>
 #include <fstream>
 #include <string>
+#include <string_view>
 #include <sstream>
 #include <thread>
 
@@ -28,6 +29,8 @@
 #include <llvm/Transforms/IPO.h>
 #include <llvm/Transforms/IPO/PassManagerBuilder.h>
 #endif
+
+using namespace std::literals;
 
 #ifndef LIBDEVICE_DIR
 #define LIBDEVICE_DIR AnyDSL_runtime_LIBDEVICE_DIR
@@ -650,6 +653,12 @@ CUmodule CudaPlatform::create_module(DeviceId dev, const std::string& filename, 
 
 const char* CudaPlatform::device_name(DeviceId dev) const {
     return devices_[dev].name.c_str();
+}
+
+bool CudaPlatform::device_check_feature_support(DeviceId dev, const char* feature) const {
+    if (feature == "ITS"sv)
+        return static_cast<int>(devices_[dev].compute_capability) >= 70;
+    return false;
 }
 
 void register_cuda_platform(Runtime* runtime) {

--- a/src/cuda_platform.h
+++ b/src/cuda_platform.h
@@ -47,6 +47,7 @@ protected:
     size_t dev_count() const override { return devices_.size(); }
     std::string name() const override { return "CUDA"; }
     const char* device_name(DeviceId dev) const override;
+    bool device_check_feature_support(DeviceId dev, const char* feature) const override;
 
     typedef std::unordered_map<std::string, CUfunction> FunctionMap;
 

--- a/src/dummy_platform.h
+++ b/src/dummy_platform.h
@@ -31,6 +31,7 @@ protected:
     size_t dev_count() const override { return 0; }
     std::string name() const override { return name_; }
     const char* device_name(DeviceId) const override { return "Dummy"; }
+    bool device_check_feature_support(DeviceId, const char*) const override { return false; }
 
     std::string name_;
 };

--- a/src/hsa_platform.h
+++ b/src/hsa_platform.h
@@ -37,6 +37,7 @@ protected:
     size_t dev_count() const override { return devices_.size(); }
     std::string name() const override { return "HSA"; }
     const char* device_name(DeviceId dev) const override;
+    bool device_check_feature_support(DeviceId, const char*) const override { return false; }
 
     struct KernelInfo {
         uint64_t kernel;

--- a/src/opencl_platform.h
+++ b/src/opencl_platform.h
@@ -43,6 +43,7 @@ protected:
     size_t dev_count() const override { return devices_.size(); }
     std::string name() const override { return "OpenCL"; }
     const char* device_name(DeviceId dev) const override;
+    bool device_check_feature_support(DeviceId, const char*) const override { return false; }
 
     typedef std::unordered_map<std::string, cl_kernel> KernelMap;
 

--- a/src/platform.h
+++ b/src/platform.h
@@ -54,6 +54,8 @@ public:
     virtual size_t dev_count() const = 0;
     /// Returns the name of the given device.
     virtual const char* device_name(DeviceId dev) const = 0;
+    /// Checks whether the given platform-specific feature is supported on the given device.
+    virtual bool device_check_feature_support(DeviceId dev, const char* feature) const = 0;
 
 protected:
     [[noreturn]] void platform_error() {

--- a/src/runtime.cpp
+++ b/src/runtime.cpp
@@ -36,6 +36,11 @@ const char* Runtime::device_name(PlatformId plat, DeviceId dev) const {
     return platforms_[plat]->device_name(dev);
 }
 
+bool Runtime::device_check_feature_support(PlatformId plat, DeviceId dev, const char* feature) const {
+    check_device(plat, dev);
+    return platforms_[plat]->device_check_feature_support(dev, feature);
+}
+
 void* Runtime::alloc(PlatformId plat, DeviceId dev, int64_t size) {
     check_device(plat, dev);
     return platforms_[plat]->alloc(dev, size);

--- a/src/runtime.h
+++ b/src/runtime.h
@@ -51,6 +51,8 @@ public:
 
     /// Returns name of device.
     const char* device_name(PlatformId, DeviceId) const;
+    /// Checks whether feature is supported on device.
+    bool device_check_feature_support(PlatformId, DeviceId, const char*) const;
 
     /// Allocates memory on the given device.
     void* alloc(PlatformId plat, DeviceId dev, int64_t size);


### PR DESCRIPTION
Introduces an `anydsl_device_arch` function to allow code to adapt based on availability of architecture-specific features.

currently only implemented for the CUDA platform, allows AnyQ CUDA mapping to know whether ITS and `nanosleep` can be used or not.