### PR TITLE
Make sure cuda library root is findable even without version.txt

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -67,7 +67,7 @@ else()
     if(CUDAToolkit_FOUND)
         # this is more robust in case CUDAToolkit_LIBRARY_ROOT is not defined
         find_path(CUDAToolkit_LIBRARY_ROOT
-            NAMES version.txt version.json
+            NAMES version.txt version.json bin/nvcc
             HINTS ${CUDAToolkit_LIBRARY_ROOT} ${CUDAToolkit_ROOT} ${CUDAToolkit_BIN_DIR}/../)
         find_library(CUDAToolkit_NVVM_LIBRARY nvvm
             HINTS ${CUDAToolkit_LIBRARY_ROOT}/nvvm


### PR DESCRIPTION
Very small addition to make sure it works with docker images provided by NVidia, which do not have the `version.txt` or `version.json`. I only added another name `bin/nvcc` as a hint to the table.