### PR TITLE
Allow user to replace and query default cache directory

### DIFF
--- a/src/anydsl_jit.h
+++ b/src/anydsl_jit.h
@@ -10,6 +10,8 @@ class Runtime;
 AnyDSL_runtime_API Runtime& runtime();
 
 #ifdef AnyDSL_runtime_HAS_JIT_SUPPORT
+AnyDSL_runtime_jit_API void anydsl_set_cache_directory(const char*);
+AnyDSL_runtime_jit_API const char* anydsl_get_cache_directory();
 AnyDSL_runtime_jit_API void anydsl_link(const char*);
 AnyDSL_runtime_jit_API int32_t anydsl_compile(const char*, uint32_t, uint32_t);
 AnyDSL_runtime_jit_API void *anydsl_lookup_function(int32_t, const char*);

--- a/src/jit.cpp
+++ b/src/jit.cpp
@@ -152,7 +152,9 @@ void anydsl_set_cache_directory(const char* dir) {
 }
 
 const char* anydsl_get_cache_directory() {
-    return jit().runtime->get_cache_directory().c_str();
+    static std::string dir;
+    dir = jit().runtime->get_cache_directory();
+    return dir.c_str();
 }
 
 void anydsl_link(const char* lib) {

--- a/src/jit.cpp
+++ b/src/jit.cpp
@@ -148,7 +148,7 @@ JIT& jit() {
 }
 
 void anydsl_set_cache_directory(const char* dir) {
-    jit().runtime->set_cache_directory(dir);
+    jit().runtime->set_cache_directory(dir == nullptr ? std::string() : dir);
 }
 
 const char* anydsl_get_cache_directory() {

--- a/src/jit.cpp
+++ b/src/jit.cpp
@@ -147,6 +147,14 @@ JIT& jit() {
     return *jit;
 }
 
+void anydsl_set_cache_directory(const char* dir) {
+    jit().runtime->set_cache_directory(dir);
+}
+
+const char* anydsl_get_cache_directory() {
+    return jit().runtime->get_cache_directory().c_str();
+}
+
 void anydsl_link(const char* lib) {
     jit().link(lib);
 }

--- a/src/runtime.cpp
+++ b/src/runtime.cpp
@@ -20,6 +20,7 @@ void register_hsa_platform(Runtime* runtime) { runtime->register_platform<DummyP
 
 Runtime::Runtime(std::pair<ProfileLevel, ProfileLevel> profile)
     : profile_(profile)
+    , cache_dir_("")
 {}
 
 void Runtime::display_info() const {
@@ -176,14 +177,22 @@ static std::string get_self_directory() {
 }
 #endif
 
-static std::string get_cache_directory() {
-    std::string cache_path = get_self_directory();
-    if (!cache_path.empty())
-        cache_path += PATH_DIR_SEPARATOR;
-    return cache_path + "cache";
+void Runtime::set_cache_directory(const std::string& dir) {
+    cache_dir_ = dir;
 }
 
-static std::string get_cached_filename(const std::string& str, const std::string& ext) {
+std::string Runtime::get_cache_directory() const {
+    if (cache_dir_.empty()) {
+        std::string cache_path = get_self_directory();
+        if (!cache_path.empty())
+            cache_path += PATH_DIR_SEPARATOR;
+        return cache_path + "cache";
+    } else {
+        return cache_dir_;
+    }
+}
+
+std::string Runtime::get_cached_filename(const std::string& str, const std::string& ext) const {
     size_t key = std::hash<std::string>{}(str);
     std::stringstream hex_stream;
     hex_stream << std::hex << key;

--- a/src/runtime.h
+++ b/src/runtime.h
@@ -86,6 +86,10 @@ public:
     void store_file(const std::string& filename, const std::string& str) const;
     void store_file(const std::string& filename, const std::byte* data, size_t size) const;
 
+    /// Set an optional directory for generated cache data. If not specified, or empty, an internal directory will be used. User has to make sure the directory exists.
+    void set_cache_directory(const std::string& dir);
+    std::string get_cache_directory() const;
+
     std::string load_from_cache(const std::string& str, const std::string& ext=".bin") const;
     void store_to_cache(const std::string& key, const std::string& str, const std::string ext=".bin") const;
 
@@ -98,11 +102,13 @@ public:
 
 private:
     void check_device(PlatformId, DeviceId) const;
+    std::string get_cached_filename(const std::string& str, const std::string& ext) const;
 
     std::pair<ProfileLevel, ProfileLevel> profile_;
     std::atomic<uint64_t> kernel_time_;
     std::vector<std::unique_ptr<Platform>> platforms_;
     std::unordered_map<std::string, std::string> files_;
+    std::string cache_dir_;
 };
 
 #endif


### PR DESCRIPTION
Currently the cache directory is based on the executable path and its parent directory. This suffice for some purposes, might fail in the general case, though.
For example, using `/usr/bin/python3` and python code with JIT compiled artic source and a CUDA kernel does not work. The directory `/usr/bin` is usually not writable for the common user. 

This PR fixes this by introducing two new functions to the JIT interface

- `anydsl_get_cache_directory` This function will return a `const char*` pointer to a string containing the current cache directory.
- `anydsl_set_cache_directory` This function will set the cache directory to a user given value, or, if empty, reset back to the default.

If `anydsl_set_cache_directory` is not used, the usual behavior is still preserved.