### PR TITLE
Add kernel name prefix

### DIFF
--- a/platforms/artic/intrinsics.impala
+++ b/platforms/artic/intrinsics.impala
@@ -21,6 +21,7 @@ struct WorkItem {
 
 struct Accelerator {
     exec          : fn(fn(WorkItem) -> ()) -> fn((i32, i32, i32), (i32, i32, i32)) -> (), // fn(grid, block)->()
+    exec_named    : fn(&[u8], fn(WorkItem) -> ()) -> fn((i32, i32, i32), (i32, i32, i32)) -> (), // fn(grid, block)->()
     sync          : fn() -> (),
     alloc         : fn(i64) -> Buffer,
     alloc_unified : fn(i64) -> Buffer,

--- a/platforms/artic/intrinsics_amdgpu.impala
+++ b/platforms/artic/intrinsics_amdgpu.impala
@@ -347,7 +347,31 @@ fn @amdgpu_accelerator(dev: i32) = Accelerator {
             nblky = @|| div_round_up(bitcast[&addrspace(4)[u32]](amdgcn_dispatch_ptr())(4) as i32, bitcast[&addrspace(4)[u16]](amdgcn_dispatch_ptr())(3) as i32),
             nblkz = @|| div_round_up(bitcast[&addrspace(4)[u32]](amdgcn_dispatch_ptr())(5) as i32, bitcast[&addrspace(4)[u16]](amdgcn_dispatch_ptr())(4) as i32)
         };
-        amdgpu(dev, grid, block, || @body(work_item))
+        amdgpu(dev, "", grid, block, || @body(work_item))
+    },
+    exec_named = @|name, body| |grid, block| {
+        fn @div_round_up(num: i32, multiple: i32) -> i32 { (num + multiple - 1) / multiple }
+        let work_item = WorkItem {
+            tidx  = amdgcn_workitem_id_x,
+            tidy  = amdgcn_workitem_id_y,
+            tidz  = amdgcn_workitem_id_z,
+            bidx  = amdgcn_workgroup_id_x,
+            bidy  = amdgcn_workgroup_id_y,
+            bidz  = amdgcn_workgroup_id_z,
+            gidx  = @|| amdgcn_workitem_id_x() + bitcast[&addrspace(4)[u16]](amdgcn_dispatch_ptr())(2) as i32 * amdgcn_workgroup_id_x(),
+            gidy  = @|| amdgcn_workitem_id_y() + bitcast[&addrspace(4)[u16]](amdgcn_dispatch_ptr())(3) as i32 * amdgcn_workgroup_id_y(),
+            gidz  = @|| amdgcn_workitem_id_z() + bitcast[&addrspace(4)[u16]](amdgcn_dispatch_ptr())(4) as i32 * amdgcn_workgroup_id_z(),
+            bdimx = @|| bitcast[&addrspace(4)[u16]](amdgcn_dispatch_ptr())(2) as i32,
+            bdimy = @|| bitcast[&addrspace(4)[u16]](amdgcn_dispatch_ptr())(3) as i32,
+            bdimz = @|| bitcast[&addrspace(4)[u16]](amdgcn_dispatch_ptr())(4) as i32,
+            gdimx = @|| bitcast[&addrspace(4)[u32]](amdgcn_dispatch_ptr())(3) as i32,
+            gdimy = @|| bitcast[&addrspace(4)[u32]](amdgcn_dispatch_ptr())(4) as i32,
+            gdimz = @|| bitcast[&addrspace(4)[u32]](amdgcn_dispatch_ptr())(5) as i32,
+            nblkx = @|| div_round_up(bitcast[&addrspace(4)[u32]](amdgcn_dispatch_ptr())(3) as i32, bitcast[&addrspace(4)[u16]](amdgcn_dispatch_ptr())(2) as i32),
+            nblky = @|| div_round_up(bitcast[&addrspace(4)[u32]](amdgcn_dispatch_ptr())(4) as i32, bitcast[&addrspace(4)[u16]](amdgcn_dispatch_ptr())(3) as i32),
+            nblkz = @|| div_round_up(bitcast[&addrspace(4)[u32]](amdgcn_dispatch_ptr())(5) as i32, bitcast[&addrspace(4)[u16]](amdgcn_dispatch_ptr())(4) as i32)
+        };
+        amdgpu(dev, name, grid, block, || @body(work_item))
     },
     sync          = @|| synchronize_hsa(dev),
     alloc         = @|size| alloc_hsa(dev, size),

--- a/platforms/artic/intrinsics_cuda.impala
+++ b/platforms/artic/intrinsics_cuda.impala
@@ -342,7 +342,30 @@ fn @cuda_accelerator(dev: i32) = Accelerator {
             nblky = cuda_gridDim_y,
             nblkz = cuda_gridDim_z
         };
-        cuda(dev, grid, block, || @body(work_item))
+        cuda(dev, "", grid, block, || @body(work_item))
+    },
+    exec_named = @|name, body| |grid, block| {
+        let work_item = WorkItem {
+            tidx  = cuda_threadIdx_x,
+            tidy  = cuda_threadIdx_y,
+            tidz  = cuda_threadIdx_z,
+            bidx  = cuda_blockIdx_x,
+            bidy  = cuda_blockIdx_y,
+            bidz  = cuda_blockIdx_z,
+            gidx  = @|| cuda_threadIdx_x() + cuda_blockDim_x() * cuda_blockIdx_x(),
+            gidy  = @|| cuda_threadIdx_y() + cuda_blockDim_y() * cuda_blockIdx_y(),
+            gidz  = @|| cuda_threadIdx_z() + cuda_blockDim_z() * cuda_blockIdx_z(),
+            bdimx = cuda_blockDim_x,
+            bdimy = cuda_blockDim_y,
+            bdimz = cuda_blockDim_z,
+            gdimx = @|| cuda_gridDim_x() * cuda_blockDim_x(),
+            gdimy = @|| cuda_gridDim_y() * cuda_blockDim_y(),
+            gdimz = @|| cuda_gridDim_z() * cuda_blockDim_z(),
+            nblkx = cuda_gridDim_x,
+            nblky = cuda_gridDim_y,
+            nblkz = cuda_gridDim_z
+        };
+        cuda(dev, name, grid, block, || @body(work_item))
     },
     sync          = @|| synchronize_cuda(dev),
     alloc         = @|size| alloc_cuda(dev, size),

--- a/platforms/artic/intrinsics_hls.impala
+++ b/platforms/artic/intrinsics_hls.impala
@@ -100,6 +100,17 @@ fn @hls_accelerator(dev: i32) = Accelerator {
         };
         hls(dev, || @body(work_item));
     },
+    exec_named = @|_, body| |_grid, _block| {
+        let work_item = WorkItem {
+            tidx  = @|| 0, tidy  = @|| 0, tidz  = @|| 0,
+            bidx  = @|| 0, bidy  = @|| 0, bidz  = @|| 0,
+            gidx  = @|| 0, gidy  = @|| 0, gidz  = @|| 0,
+            bdimx = @|| 1, bdimy = @|| 1, bdimz = @|| 1,
+            gdimx = @|| 1, gdimy = @|| 1, gdimz = @|| 1,
+            nblkx = @|| 1, nblky = @|| 1, nblkz = @|| 1
+        };
+        hls(dev, || @body(work_item));
+    },
     sync          = @|| synchronize_hls(dev),
     alloc         = @|size| alloc_hls(dev, size),
     alloc_unified = @|size| alloc_hls_unified(dev, size),

--- a/platforms/artic/intrinsics_nvvm.impala
+++ b/platforms/artic/intrinsics_nvvm.impala
@@ -593,7 +593,30 @@ fn @nvvm_accelerator(dev: i32) = Accelerator {
             nblky = nvvm_read_ptx_sreg_nctaid_y,
             nblkz = nvvm_read_ptx_sreg_nctaid_z
         };
-        nvvm(dev, grid, block, || @body(work_item))
+        nvvm(dev, "", grid, block, || @body(work_item))
+    },
+    exec_named = @|name, body| |grid, block| {
+        let work_item = WorkItem {
+            tidx  = nvvm_read_ptx_sreg_tid_x,
+            tidy  = nvvm_read_ptx_sreg_tid_y,
+            tidz  = nvvm_read_ptx_sreg_tid_z,
+            bidx  = nvvm_read_ptx_sreg_ctaid_x,
+            bidy  = nvvm_read_ptx_sreg_ctaid_y,
+            bidz  = nvvm_read_ptx_sreg_ctaid_z,
+            gidx  = @|| nvvm_read_ptx_sreg_tid_x() + nvvm_read_ptx_sreg_ntid_x() * nvvm_read_ptx_sreg_ctaid_x(),
+            gidy  = @|| nvvm_read_ptx_sreg_tid_y() + nvvm_read_ptx_sreg_ntid_y() * nvvm_read_ptx_sreg_ctaid_y(),
+            gidz  = @|| nvvm_read_ptx_sreg_tid_z() + nvvm_read_ptx_sreg_ntid_z() * nvvm_read_ptx_sreg_ctaid_z(),
+            bdimx = nvvm_read_ptx_sreg_ntid_x,
+            bdimy = nvvm_read_ptx_sreg_ntid_y,
+            bdimz = nvvm_read_ptx_sreg_ntid_z,
+            gdimx = @|| nvvm_read_ptx_sreg_nctaid_x() * nvvm_read_ptx_sreg_ntid_x(),
+            gdimy = @|| nvvm_read_ptx_sreg_nctaid_y() * nvvm_read_ptx_sreg_ntid_y(),
+            gdimz = @|| nvvm_read_ptx_sreg_nctaid_z() * nvvm_read_ptx_sreg_ntid_z(),
+            nblkx = nvvm_read_ptx_sreg_nctaid_x,
+            nblky = nvvm_read_ptx_sreg_nctaid_y,
+            nblkz = nvvm_read_ptx_sreg_nctaid_z
+        };
+        nvvm(dev, name, grid, block, || @body(work_item))
     },
     sync          = @|| synchronize_cuda(dev),
     alloc         = @|size| alloc_cuda(dev, size),

--- a/platforms/artic/intrinsics_opencl.impala
+++ b/platforms/artic/intrinsics_opencl.impala
@@ -71,7 +71,7 @@ static CLK_LOCAL_MEM_FENCE  = 1:u32;
 static CLK_GLOBAL_MEM_FENCE = 2:u32;
 
 fn @opencl_accelerator(dev: i32) = Accelerator {
-    exec          = @|body| |grid, block| {
+    exec = @|body| |grid, block| {
         let work_item = WorkItem {
             tidx  = @|| opencl_get_local_id(0) as i32,
             tidy  = @|| opencl_get_local_id(1) as i32,
@@ -92,7 +92,30 @@ fn @opencl_accelerator(dev: i32) = Accelerator {
             nblky = @|| opencl_get_num_groups(1) as i32,
             nblkz = @|| opencl_get_num_groups(2) as i32
         };
-        opencl(dev, grid, block, || @body(work_item))
+        opencl(dev, "", grid, block, || @body(work_item))
+    },
+    exec_named = @|name, body| |grid, block| {
+        let work_item = WorkItem {
+            tidx  = @|| opencl_get_local_id(0) as i32,
+            tidy  = @|| opencl_get_local_id(1) as i32,
+            tidz  = @|| opencl_get_local_id(2) as i32,
+            bidx  = @|| opencl_get_group_id(0) as i32,
+            bidy  = @|| opencl_get_group_id(1) as i32,
+            bidz  = @|| opencl_get_group_id(2) as i32,
+            gidx  = @|| opencl_get_global_id(0) as i32,
+            gidy  = @|| opencl_get_global_id(1) as i32,
+            gidz  = @|| opencl_get_global_id(2) as i32,
+            bdimx = @|| opencl_get_local_size(0) as i32,
+            bdimy = @|| opencl_get_local_size(1) as i32,
+            bdimz = @|| opencl_get_local_size(2) as i32,
+            gdimx = @|| opencl_get_global_size(0) as i32,
+            gdimy = @|| opencl_get_global_size(1) as i32,
+            gdimz = @|| opencl_get_global_size(2) as i32,
+            nblkx = @|| opencl_get_num_groups(0) as i32,
+            nblky = @|| opencl_get_num_groups(1) as i32,
+            nblkz = @|| opencl_get_num_groups(2) as i32
+        };
+        opencl(dev, name, grid, block, || @body(work_item))
     },
     sync          = @|| synchronize_opencl(dev),
     alloc         = @|size| alloc_opencl(dev, size),

--- a/platforms/artic/intrinsics_thorin.impala
+++ b/platforms/artic/intrinsics_thorin.impala
@@ -12,10 +12,10 @@
 #[import(cc = "thorin")] fn cmpxchg_weak[T](_addr: &mut T, _cmp: T, _new: T, _success_order: u32, _failure_order: u32, _scope: &[u8]) -> (T, bool); // only for integer data types
 #[import(cc = "thorin")] fn fence(_order: u32, _scope: &[u8]) -> ();
 #[import(cc = "thorin")] fn pe_info[T](_src: &[u8], _val: T) -> ();
-#[import(cc = "thorin")] fn cuda(_dev: i32, _grid: (i32, i32, i32), _block: (i32, i32, i32), _body: fn() -> ()) -> ();
-#[import(cc = "thorin")] fn nvvm(_dev: i32, _grid: (i32, i32, i32), _block: (i32, i32, i32), _body: fn() -> ()) -> ();
-#[import(cc = "thorin")] fn opencl(_dev: i32, _grid: (i32, i32, i32), _block: (i32, i32, i32), _body: fn() -> ()) -> ();
-#[import(cc = "thorin")] fn amdgpu(_dev: i32, _grid: (i32, i32, i32), _block: (i32, i32, i32), _body: fn() -> ()) -> ();
+#[import(cc = "thorin")] fn cuda(_dev: i32, _name: &[u8], _grid: (i32, i32, i32), _block: (i32, i32, i32), _body: fn() -> ()) -> ();
+#[import(cc = "thorin")] fn nvvm(_dev: i32, _name: &[u8], _grid: (i32, i32, i32), _block: (i32, i32, i32), _body: fn() -> ()) -> ();
+#[import(cc = "thorin")] fn opencl(_dev: i32, _name: &[u8], _grid: (i32, i32, i32), _block: (i32, i32, i32), _body: fn() -> ()) -> ();
+#[import(cc = "thorin")] fn amdgpu(_dev: i32, _name: &[u8], _grid: (i32, i32, i32), _block: (i32, i32, i32), _body: fn() -> ()) -> ();
 #[import(cc = "thorin")] fn reserve_shared[T](_size: i32) -> &mut addrspace(3)[T];
 #[import(cc = "thorin")] fn hls(_dev: i32, _body: fn() -> ()) -> ();
 #[import(cc = "thorin", name = "pipeline")] fn thorin_pipeline(_initiation_interval: i32, _lower: i32, _upper: i32, _body: fn(i32) -> ()) -> (); // only for HLS/OpenCL backend

--- a/platforms/impala/intrinsics.impala
+++ b/platforms/impala/intrinsics.impala
@@ -23,6 +23,10 @@ struct Accelerator {
     exec          : fn((i32, i32, i32), // grid
                        (i32, i32, i32), // block
                        fn(WorkItem) -> ()) -> (),
+    exec_named    : fn(&[u8],           // prefix
+                       (i32, i32, i32), // grid
+                       (i32, i32, i32), // block
+                       fn(WorkItem) -> ()) -> (),
     sync          : fn() -> (),
     alloc         : fn(i64) -> Buffer,
     alloc_unified : fn(i64) -> Buffer,

--- a/platforms/impala/intrinsics_amdgpu.impala
+++ b/platforms/impala/intrinsics_amdgpu.impala
@@ -331,7 +331,7 @@ struct hsa_dispatch_packet_t {
 fn @amdgpu_accelerator(dev: i32) -> Accelerator {
     fn @div_round_up(num: i32, multiple: i32) -> i32 { (num + multiple - 1) / multiple }
     Accelerator {
-        exec          : @|grid, block, body| {
+        exec : @|grid, block, body| {
             let work_item = WorkItem {
                 tidx  : amdgcn_workitem_id_x,
                 tidy  : amdgcn_workitem_id_y,
@@ -352,7 +352,30 @@ fn @amdgpu_accelerator(dev: i32) -> Accelerator {
                 nblky : @|| div_round_up(bitcast[&[4][u32]](amdgcn_dispatch_ptr())(4) as i32, bitcast[&[4][u16]](amdgcn_dispatch_ptr())(3) as i32),
                 nblkz : @|| div_round_up(bitcast[&[4][u32]](amdgcn_dispatch_ptr())(5) as i32, bitcast[&[4][u16]](amdgcn_dispatch_ptr())(4) as i32)
             };
-            amdgpu(dev, grid, block, || body(work_item))
+            amdgpu(dev, "", grid, block, || body(work_item))
+        },
+        exec_named : @|name, grid, block, body| {
+            let work_item = WorkItem {
+                tidx  : amdgcn_workitem_id_x,
+                tidy  : amdgcn_workitem_id_y,
+                tidz  : amdgcn_workitem_id_z,
+                bidx  : amdgcn_workgroup_id_x,
+                bidy  : amdgcn_workgroup_id_y,
+                bidz  : amdgcn_workgroup_id_z,
+                gidx  : @|| amdgcn_workitem_id_x() + bitcast[&[4][u16]](amdgcn_dispatch_ptr())(2) as i32 * amdgcn_workgroup_id_x(),
+                gidy  : @|| amdgcn_workitem_id_y() + bitcast[&[4][u16]](amdgcn_dispatch_ptr())(3) as i32 * amdgcn_workgroup_id_y(),
+                gidz  : @|| amdgcn_workitem_id_z() + bitcast[&[4][u16]](amdgcn_dispatch_ptr())(4) as i32 * amdgcn_workgroup_id_z(),
+                bdimx : @|| bitcast[&[4][u16]](amdgcn_dispatch_ptr())(2) as i32,
+                bdimy : @|| bitcast[&[4][u16]](amdgcn_dispatch_ptr())(3) as i32,
+                bdimz : @|| bitcast[&[4][u16]](amdgcn_dispatch_ptr())(4) as i32,
+                gdimx : @|| bitcast[&[4][u32]](amdgcn_dispatch_ptr())(3) as i32,
+                gdimy : @|| bitcast[&[4][u32]](amdgcn_dispatch_ptr())(4) as i32,
+                gdimz : @|| bitcast[&[4][u32]](amdgcn_dispatch_ptr())(5) as i32,
+                nblkx : @|| div_round_up(bitcast[&[4][u32]](amdgcn_dispatch_ptr())(3) as i32, bitcast[&[4][u16]](amdgcn_dispatch_ptr())(2) as i32),
+                nblky : @|| div_round_up(bitcast[&[4][u32]](amdgcn_dispatch_ptr())(4) as i32, bitcast[&[4][u16]](amdgcn_dispatch_ptr())(3) as i32),
+                nblkz : @|| div_round_up(bitcast[&[4][u32]](amdgcn_dispatch_ptr())(5) as i32, bitcast[&[4][u16]](amdgcn_dispatch_ptr())(4) as i32)
+            };
+            amdgpu(dev, name, grid, block, || body(work_item))
         },
         sync          : @|| synchronize_hsa(dev),
         alloc         : @|size| alloc_hsa(dev, size),

--- a/platforms/impala/intrinsics_cuda.impala
+++ b/platforms/impala/intrinsics_cuda.impala
@@ -344,7 +344,30 @@ fn @cuda_accelerator(dev: i32) -> Accelerator {
                 nblky : cuda_gridDim_y,
                 nblkz : cuda_gridDim_z
             };
-            cuda(dev, grid, block, || @@body(work_item))
+            cuda(dev, "", grid, block, || @@body(work_item))
+        },
+        exec_named : @|name, grid, block, body| {
+            let work_item = WorkItem {
+                tidx  : cuda_threadIdx_x,
+                tidy  : cuda_threadIdx_y,
+                tidz  : cuda_threadIdx_z,
+                bidx  : cuda_blockIdx_x,
+                bidy  : cuda_blockIdx_y,
+                bidz  : cuda_blockIdx_z,
+                gidx  : @|| cuda_threadIdx_x() + cuda_blockDim_x() * cuda_blockIdx_x(),
+                gidy  : @|| cuda_threadIdx_y() + cuda_blockDim_y() * cuda_blockIdx_y(),
+                gidz  : @|| cuda_threadIdx_z() + cuda_blockDim_z() * cuda_blockIdx_z(),
+                bdimx : cuda_blockDim_x,
+                bdimy : cuda_blockDim_y,
+                bdimz : cuda_blockDim_z,
+                gdimx : @|| cuda_gridDim_x() * cuda_blockDim_x(),
+                gdimy : @|| cuda_gridDim_y() * cuda_blockDim_y(),
+                gdimz : @|| cuda_gridDim_z() * cuda_blockDim_z(),
+                nblkx : cuda_gridDim_x,
+                nblky : cuda_gridDim_y,
+                nblkz : cuda_gridDim_z
+            };
+            cuda(dev, name, grid, block, || @@body(work_item))
         },
         sync          : @|| synchronize_cuda(dev),
         alloc         : @|size| alloc_cuda(dev, size),

--- a/platforms/impala/intrinsics_hls.impala
+++ b/platforms/impala/intrinsics_hls.impala
@@ -177,6 +177,17 @@ fn @hls_accelerator(dev: i32) -> Accelerator {
             };
             hls(dev, || @@body(work_item));
         },
+        exec_named          : @|_, grid, block, body| {
+            let work_item = WorkItem {
+                tidx  : @|| 0, tidy  : @|| 0, tidz  : @|| 0,
+                bidx  : @|| 0, bidy  : @|| 0, bidz  : @|| 0,
+                gidx  : @|| 0, gidy  : @|| 0, gidz  : @|| 0,
+                bdimx : @|| 1, bdimy : @|| 1, bdimz : @|| 1,
+                gdimx : @|| 1, gdimy : @|| 1, gdimz : @|| 1,
+                nblkx : @|| 1, nblky : @|| 1, nblkz : @|| 1
+            };
+            hls(dev, || @@body(work_item));
+        },
         sync          : @|| synchronize_hls(dev),
         alloc         : @|size| alloc_hls(dev, size),
         alloc_unified : @|size| alloc_hls_unified(dev, size),

--- a/platforms/impala/intrinsics_nvvm.impala
+++ b/platforms/impala/intrinsics_nvvm.impala
@@ -602,7 +602,30 @@ fn @nvvm_accelerator(dev: i32) -> Accelerator {
                 nblky : nvvm_read_ptx_sreg_nctaid_y,
                 nblkz : nvvm_read_ptx_sreg_nctaid_z
             };
-            nvvm(dev, grid, block, || @@body(work_item))
+            nvvm(dev, "", grid, block, || @@body(work_item))
+        },
+        exec_named : @|name, grid, block, body| {
+            let work_item = WorkItem {
+                tidx  : nvvm_read_ptx_sreg_tid_x,
+                tidy  : nvvm_read_ptx_sreg_tid_y,
+                tidz  : nvvm_read_ptx_sreg_tid_z,
+                bidx  : nvvm_read_ptx_sreg_ctaid_x,
+                bidy  : nvvm_read_ptx_sreg_ctaid_y,
+                bidz  : nvvm_read_ptx_sreg_ctaid_z,
+                gidx  : @|| nvvm_read_ptx_sreg_tid_x() + nvvm_read_ptx_sreg_ntid_x() * nvvm_read_ptx_sreg_ctaid_x(),
+                gidy  : @|| nvvm_read_ptx_sreg_tid_y() + nvvm_read_ptx_sreg_ntid_y() * nvvm_read_ptx_sreg_ctaid_y(),
+                gidz  : @|| nvvm_read_ptx_sreg_tid_z() + nvvm_read_ptx_sreg_ntid_z() * nvvm_read_ptx_sreg_ctaid_z(),
+                bdimx : nvvm_read_ptx_sreg_ntid_x,
+                bdimy : nvvm_read_ptx_sreg_ntid_y,
+                bdimz : nvvm_read_ptx_sreg_ntid_z,
+                gdimx : @|| nvvm_read_ptx_sreg_nctaid_x() * nvvm_read_ptx_sreg_ntid_x(),
+                gdimy : @|| nvvm_read_ptx_sreg_nctaid_y() * nvvm_read_ptx_sreg_ntid_y(),
+                gdimz : @|| nvvm_read_ptx_sreg_nctaid_z() * nvvm_read_ptx_sreg_ntid_z(),
+                nblkx : nvvm_read_ptx_sreg_nctaid_x,
+                nblky : nvvm_read_ptx_sreg_nctaid_y,
+                nblkz : nvvm_read_ptx_sreg_nctaid_z
+            };
+            nvvm(dev, name, grid, block, || @@body(work_item))
         },
         sync          : @|| synchronize_cuda(dev),
         alloc         : @|size| alloc_cuda(dev, size),

--- a/platforms/impala/intrinsics_opencl.impala
+++ b/platforms/impala/intrinsics_opencl.impala
@@ -92,7 +92,30 @@ fn @opencl_accelerator(dev: i32) -> Accelerator {
                 nblky : @|| opencl_get_num_groups(1u32) as i32,
                 nblkz : @|| opencl_get_num_groups(2u32) as i32
             };
-            opencl(dev, grid, block, || @@body(work_item))
+            opencl(dev, "", grid, block, || @@body(work_item))
+        },
+        exec_named          : @|name, grid, block, body| {
+            let work_item = WorkItem {
+                tidx  : @|| opencl_get_local_id(0u32) as i32,
+                tidy  : @|| opencl_get_local_id(1u32) as i32,
+                tidz  : @|| opencl_get_local_id(2u32) as i32,
+                bidx  : @|| opencl_get_group_id(0u32) as i32,
+                bidy  : @|| opencl_get_group_id(1u32) as i32,
+                bidz  : @|| opencl_get_group_id(2u32) as i32,
+                gidx  : @|| opencl_get_global_id(0u32) as i32,
+                gidy  : @|| opencl_get_global_id(1u32) as i32,
+                gidz  : @|| opencl_get_global_id(2u32) as i32,
+                bdimx : @|| opencl_get_local_size(0u32) as i32,
+                bdimy : @|| opencl_get_local_size(1u32) as i32,
+                bdimz : @|| opencl_get_local_size(2u32) as i32,
+                gdimx : @|| opencl_get_global_size(0u32) as i32,
+                gdimy : @|| opencl_get_global_size(1u32) as i32,
+                gdimz : @|| opencl_get_global_size(2u32) as i32,
+                nblkx : @|| opencl_get_num_groups(0u32) as i32,
+                nblky : @|| opencl_get_num_groups(1u32) as i32,
+                nblkz : @|| opencl_get_num_groups(2u32) as i32
+            };
+            opencl(dev, name, grid, block, || @@body(work_item))
         },
         sync          : @|| synchronize_opencl(dev),
         alloc         : @|size| alloc_opencl(dev, size),

--- a/platforms/impala/intrinsics_thorin.impala
+++ b/platforms/impala/intrinsics_thorin.impala
@@ -10,10 +10,10 @@ extern "thorin" {
     fn insert[T, U](T, i32, U) -> T;
     //fn shuffle[T](T, T, T) -> T;
 
-    fn cuda(i32, (i32, i32, i32), (i32, i32, i32), fn() -> ()) -> ();
-    fn nvvm(i32, (i32, i32, i32), (i32, i32, i32), fn() -> ()) -> ();
-    fn opencl(i32, (i32, i32, i32), (i32, i32, i32), fn() -> ()) -> ();
-    fn amdgpu(i32, (i32, i32, i32), (i32, i32, i32), fn() -> ()) -> ();
+    fn cuda(i32, &[u8], (i32, i32, i32), (i32, i32, i32), fn() -> ()) -> ();
+    fn nvvm(i32, &[u8], (i32, i32, i32), (i32, i32, i32), fn() -> ()) -> ();
+    fn opencl(i32, &[u8], (i32, i32, i32), (i32, i32, i32), fn() -> ()) -> ();
+    fn amdgpu(i32, &[u8], (i32, i32, i32), (i32, i32, i32), fn() -> ()) -> ();
     fn reserve_shared[T](i32) -> &mut[3][T];
 
     fn hls(dev: i32, body: fn() -> ()) -> ();


### PR DESCRIPTION
Add optional kernel prefix for IR debugging and diagnosis.
Changes internal intrinsics, but the Accelerator interface is only extended and is backwards compatible.
