### PR TITLE
Add initial support for events on CPU & CUDA

### DIFF
--- a/platforms/artic/runtime.impala
+++ b/platforms/artic/runtime.impala
@@ -31,6 +31,13 @@
 #[import(cc = "C", name = "anydsl_print_string")] fn print_string(_: &[u8]) -> ();
 #[import(cc = "C", name = "anydsl_print_flush")]  fn print_flush() -> ();
 
+#[import(cc = "C", name = "anydsl_create_event")]   fn runtime_create_event(_device: i32) -> u64;
+#[import(cc = "C", name = "anydsl_destroy_event")]  fn runtime_destroy_event(_device: i32, _event: u64) -> ();
+#[import(cc = "C", name = "anydsl_record_event")]   fn runtime_record_event(_device: i32, _event: u64) -> ();
+#[import(cc = "C", name = "anydsl_check_event")]    fn runtime_check_event(_device: i32, _event: u64) -> bool;
+#[import(cc = "C", name = "anydsl_query_us_event")] fn runtime_query_us_event(_device: i32, _event_start: u64, _event_end: u64) -> u64;
+#[import(cc = "C", name = "anydsl_sync_event")]     fn runtime_sync_event(_device: i32, _event: u64) -> ();
+
 // TODO
 //struct Buffer[T] {
 //    data : &mut [T],

--- a/platforms/impala/runtime.impala
+++ b/platforms/impala/runtime.impala
@@ -31,6 +31,13 @@ extern "C" {
     fn "anydsl_print_char"   print_char(u8) -> ();
     fn "anydsl_print_string" print_string(&[u8]) -> ();
     fn "anydsl_print_flush"  print_flush() -> ();
+
+    fn "anydsl_create_event"   runtime_create_event(_device: i32) -> u64;
+    fn "anydsl_destroy_event"  runtime_destroy_event(_device: i32, _event: u64) -> ();
+    fn "anydsl_record_event"   runtime_record_event(_device: i32, _event: u64) -> ();
+    fn "anydsl_check_event"    runtime_check_event(_device: i32, _event: u64) -> bool;
+    fn "anydsl_query_us_event" runtime_query_us_event(_device: i32, _event_start: u64, _event_end: u64) -> u64;
+    fn "anydsl_sync_event"     runtime_sync_event(_device: i32, _event: u64) -> ();
 }
 
 struct Buffer {

--- a/src/anydsl_runtime.cpp
+++ b/src/anydsl_runtime.cpp
@@ -209,6 +209,33 @@ uint64_t anydsl_random_val_u64() {
     return std_dist_u64(std_gen);
 }
 
+// Event stuff
+//----------------------------------------------
+
+anydsl_event_t anydsl_create_event(int32_t mask) {
+    return runtime().create_event(to_platform(mask), to_device(mask));
+}
+
+void anydsl_destroy_event(int32_t mask, anydsl_event_t event) {
+    runtime().destroy_event(to_platform(mask), to_device(mask), event);
+}
+
+void anydsl_record_event(int32_t mask, anydsl_event_t event) {
+    runtime().record_event(to_platform(mask), to_device(mask), event);
+}
+
+bool anydsl_check_event(int32_t mask, anydsl_event_t event) {
+    return runtime().check_event(to_platform(mask), to_device(mask), event);
+}
+
+uint64_t anydsl_query_us_event(int32_t mask, anydsl_event_t event_start, anydsl_event_t event_end) {
+    return runtime().query_us_event(to_platform(mask), to_device(mask), event_start, event_end);
+}
+
+void anydsl_sync_event(int32_t mask, anydsl_event_t event) {
+    runtime().sync_event(to_platform(mask), to_device(mask), event);
+}
+
 #ifndef AnyDSL_runtime_HAS_TBB_SUPPORT // C++11 threads version
 static std::unordered_map<int32_t, std::thread> thread_pool;
 static std::vector<int32_t> free_ids;

--- a/src/anydsl_runtime.h
+++ b/src/anydsl_runtime.h
@@ -84,6 +84,20 @@ AnyDSL_runtime_API int32_t anydsl_create_task(int32_t, Closure);
 AnyDSL_runtime_API void    anydsl_create_edge(int32_t, int32_t);
 AnyDSL_runtime_API void    anydsl_execute_graph(int32_t, int32_t);
 
+typedef uint64_t anydsl_event_t;
+/// Create event for device. Will return id of event
+AnyDSL_runtime_API anydsl_event_t anydsl_create_event(int32_t);
+/// Destroy event
+AnyDSL_runtime_API void anydsl_destroy_event(int32_t, anydsl_event_t);
+/// Record the event for the device
+AnyDSL_runtime_API void anydsl_record_event(int32_t, anydsl_event_t);
+/// Check if event has completed. True if the event is completed, false otherwise
+AnyDSL_runtime_API bool anydsl_check_event(int32_t, anydsl_event_t);
+/// Query time between two events in micro seconds. Both events have to be completed, else UINT64_MAX is returned
+AnyDSL_runtime_API uint64_t anydsl_query_us_event(int32_t, anydsl_event_t, anydsl_event_t);
+/// Wait for the event to complete
+AnyDSL_runtime_API void anydsl_sync_event(int32_t, anydsl_event_t);
+
 #ifdef __cplusplus
 }
 #include "anydsl_runtime.hpp"

--- a/src/cpu_platform.h
+++ b/src/cpu_platform.h
@@ -67,7 +67,14 @@ protected:
     size_t dev_count() const override { return 1; }
     std::string name() const override { return "CPU"; }
     const char* device_name(DeviceId) const override { return device_name_.c_str(); }
-    bool device_check_feature_support(DeviceId, const char*) const override { return false; }
+    bool device_check_feature_support(DeviceId, const char*) const override;
+
+    EventId create_event(DeviceId dev) override;
+    void destroy_event(DeviceId dev, EventId event) override;
+    void record_event(DeviceId dev, EventId event) override;
+    bool check_event(DeviceId dev, EventId event) override;
+    uint64_t query_us_event(DeviceId dev, EventId event_start, EventId event_end) override;
+    void sync_event(DeviceId dev, EventId event) override;
 };
 
 #endif

--- a/src/cuda_platform.cpp
+++ b/src/cuda_platform.cpp
@@ -697,9 +697,57 @@ const char* CudaPlatform::device_name(DeviceId dev) const {
 bool CudaPlatform::device_check_feature_support(DeviceId dev, const char* feature) const {
     if (feature == "ITS"sv)
         return static_cast<int>(devices_[dev].compute_capability) >= 70;
+    if (feature == "event"sv)
+        return true;
     return false;
+}
+
+EventId CudaPlatform::create_event(DeviceId) {
+    CUevent event;
+    CHECK_CUDA(cuEventCreate(&event, CU_EVENT_DEFAULT), "cuEventCreate()");
+    return (EventId)reinterpret_cast<uintptr_t>(event);
+}
+
+void CudaPlatform::destroy_event(DeviceId, EventId event) {
+    auto eventPtr = reinterpret_cast<CUevent>((uintptr_t)event);
+    CHECK_CUDA(cuEventDestroy(eventPtr), "cuEventDestroy");
+}
+
+void CudaPlatform::record_event(DeviceId, EventId event) {
+    auto eventPtr = reinterpret_cast<CUevent>((uintptr_t)event);
+    CHECK_CUDA(cuEventRecord(eventPtr, 0), "cuEventRecord");
+}
+
+bool CudaPlatform::check_event(DeviceId, EventId event) {
+    auto eventPtr = reinterpret_cast<CUevent>((uintptr_t)event);
+
+    CUresult err = cuEventQuery(eventPtr);
+    if (err == CUDA_ERROR_NOT_READY)
+        return false;
+
+    CHECK_CUDA(err, "cuEventQuery");
+    return err == CUDA_SUCCESS;
+}
+
+uint64_t CudaPlatform::query_us_event(DeviceId, EventId event_start, EventId event_end) {
+    auto eventStartPtr = reinterpret_cast<CUevent>((uintptr_t)event_start);
+    auto eventEndPtr = reinterpret_cast<CUevent>((uintptr_t)event_end);
+
+    float milliseconds;
+    CUresult err = cuEventElapsedTime(&milliseconds, eventStartPtr, eventEndPtr);
+    if (err == CUDA_ERROR_NOT_READY)
+        return UINT64_MAX;
+
+    CHECK_CUDA(err, "cuEventElapsedTime");
+    return static_cast<uint64_t>(milliseconds * 1000);
+}
+
+void CudaPlatform::sync_event(DeviceId, EventId event){
+    auto eventPtr = reinterpret_cast<CUevent>((uintptr_t)event);
+    CHECK_CUDA(cuEventSynchronize(eventPtr), "cuEventSynchronize");
 }
 
 void register_cuda_platform(Runtime* runtime) {
     runtime->register_platform<CudaPlatform>();
 }
+

--- a/src/cuda_platform.h
+++ b/src/cuda_platform.h
@@ -101,6 +101,13 @@ protected:
     std::string compile_nvvm(DeviceId dev, const std::string& filename, const std::string& program_string) const;
     std::string compile_cuda(DeviceId dev, const std::string& filename, const std::string& program_string) const;
     CUmodule create_module(DeviceId dev, const std::string& filename, const std::string& ptx_string) const;
+
+    EventId create_event(DeviceId dev) override;
+    void destroy_event(DeviceId dev, EventId event) override;
+    void record_event(DeviceId dev, EventId event) override;
+    bool check_event(DeviceId dev, EventId event) override;
+    uint64_t query_us_event(DeviceId dev, EventId event_start, EventId event_end) override;
+    void sync_event(DeviceId dev, EventId event) override;
 };
 
 #endif

--- a/src/dummy_platform.h
+++ b/src/dummy_platform.h
@@ -34,6 +34,13 @@ protected:
     bool device_check_feature_support(DeviceId, const char*) const override { return false; }
 
     std::string name_;
+
+    EventId create_event(DeviceId) override { platform_error(); return 0; }
+    void destroy_event(DeviceId, EventId) override { platform_error(); }
+    void record_event(DeviceId, EventId) override { platform_error(); }
+    bool check_event(DeviceId, EventId) override { platform_error(); return false; }
+    uint64_t query_us_event(DeviceId, EventId, EventId) override { platform_error(); return 0; }
+    void sync_event(DeviceId, EventId) override { platform_error(); }
 };
 
 #endif

--- a/src/hsa_platform.h
+++ b/src/hsa_platform.h
@@ -107,6 +107,13 @@ protected:
     KernelInfo& load_kernel(DeviceId, const std::string&, const std::string&);
     std::string compile_gcn(DeviceId, const std::string&, const std::string&) const;
     std::string emit_gcn(const std::string&, const std::string&, const std::string&, llvm::OptimizationLevel) const;
+
+    EventId create_event(DeviceId) override { command_unavailable("create_event"); return 0; }
+    void destroy_event(DeviceId, EventId) override { command_unavailable("destroy_event"); }
+    void record_event(DeviceId, EventId) override { command_unavailable("record_event"); }
+    bool check_event(DeviceId, EventId) override { command_unavailable("check_event"); return false; }
+    uint64_t query_us_event(DeviceId, EventId, EventId) override { command_unavailable("query_us_event"); return 0; }
+    void sync_event(DeviceId, EventId) override { command_unavailable("sync_event"); }
 };
 
 #endif

--- a/src/opencl_platform.h
+++ b/src/opencl_platform.h
@@ -111,6 +111,13 @@ protected:
     cl_program compile_program(DeviceId dev, cl_program program, const std::string& filename) const;
 
     friend void time_kernel_callback(cl_event, cl_int, void*);
+
+    EventId create_event(DeviceId) override { command_unavailable("create_event"); return 0; }
+    void destroy_event(DeviceId, EventId) override { command_unavailable("destroy_event"); }
+    void record_event(DeviceId, EventId) override { command_unavailable("record_event"); }
+    bool check_event(DeviceId, EventId) override { command_unavailable("check_event"); return false; }
+    uint64_t query_us_event(DeviceId, EventId, EventId) override { command_unavailable("query_us_event"); return 0; }
+    void sync_event(DeviceId, EventId) override { command_unavailable("sync_event"); }
 };
 
 #endif

--- a/src/platform.h
+++ b/src/platform.h
@@ -57,6 +57,12 @@ public:
     /// Checks whether the given platform-specific feature is supported on the given device.
     virtual bool device_check_feature_support(DeviceId dev, const char* feature) const = 0;
 
+    virtual EventId create_event(DeviceId) = 0;
+    virtual void destroy_event(DeviceId, EventId) = 0;
+    virtual void record_event(DeviceId, EventId) = 0;
+    virtual bool check_event(DeviceId, EventId) = 0;
+    virtual uint64_t query_us_event(DeviceId, EventId, EventId) = 0;
+    virtual void sync_event(DeviceId, EventId) = 0;
 protected:
     [[noreturn]] void platform_error() {
         error("The selected '%' platform is not available", name());

--- a/src/runtime.cpp
+++ b/src/runtime.cpp
@@ -111,6 +111,36 @@ void Runtime::synchronize(PlatformId plat, DeviceId dev) {
     platforms_[plat]->synchronize(dev);
 }
 
+uint64_t Runtime::create_event(PlatformId plat, DeviceId dev) {
+    check_device(plat, dev);
+    return platforms_[plat]->create_event(dev);
+}
+
+void Runtime::destroy_event(PlatformId plat, DeviceId dev, uint64_t event) {
+    check_device(plat, dev);
+    platforms_[plat]->destroy_event(dev, event);
+}
+
+void Runtime::record_event(PlatformId plat, DeviceId dev, uint64_t event) {
+    check_device(plat, dev);
+    platforms_[plat]->record_event(dev, event);
+}
+
+bool Runtime::check_event(PlatformId plat, DeviceId dev, uint64_t event) {
+    check_device(plat, dev);
+    return platforms_[plat]->check_event(dev, event);
+}
+
+uint64_t Runtime::query_us_event(PlatformId plat, DeviceId dev, uint64_t event_start, uint64_t event_end) {
+    check_device(plat, dev);
+    return platforms_[plat]->query_us_event(dev, event_start, event_end);
+}
+
+void Runtime::sync_event(PlatformId plat, DeviceId dev, uint64_t event) {
+    check_device(plat, dev);
+    platforms_[plat]->sync_event(dev, event);
+}
+
 #ifdef _WIN32
 #include <direct.h>
 #define PATH_DIR_SEPARATOR '\\'

--- a/src/runtime.h
+++ b/src/runtime.h
@@ -17,6 +17,8 @@ enum DeviceId   : uint32_t {};
 enum PlatformId : uint32_t {};
 enum class ProfileLevel : uint8_t { None = 0, Full, Fpga_dynamic };
 
+using EventId = uint64_t;
+
 class Platform;
 
 enum class KernelArgType : uint8_t { Val = 0, Ptr, Struct };
@@ -99,6 +101,13 @@ public:
 
     static void* aligned_malloc(size_t, size_t);
     static void aligned_free(void*);
+
+    EventId create_event(PlatformId plat, DeviceId dev);
+    void destroy_event(PlatformId plat, DeviceId dev, EventId event);
+    void record_event(PlatformId plat, DeviceId dev, EventId event);
+    bool check_event(PlatformId plat, DeviceId dev, EventId event);
+    uint64_t query_us_event(PlatformId plat, DeviceId dev, EventId event_start, EventId event_end);
+    void sync_event(PlatformId plat, DeviceId dev, EventId event);
 
 private:
     void check_device(PlatformId, DeviceId) const;


### PR DESCRIPTION
This PR adds event support to AnyDSL runtime.
Currently, only CPU & Cuda devices are supported. Support can be queried via `device_check_feature_support` and "event".
Might add HSA support in the future.
The new runtime c functions are:
```
anydsl_event_t anydsl_create_event(int32_t);
void anydsl_destroy_event(int32_t, anydsl_event_t);
void anydsl_record_event(int32_t, anydsl_event_t);
bool anydsl_check_event(int32_t, anydsl_event_t);
uint64_t anydsl_query_us_event(int32_t, anydsl_event_t, anydsl_event_t);
void anydsl_sync_event(int32_t, anydsl_event_t);
```

Similar interface added to Artic and Impala.
Tested on Rodent (Artic).

Note: The 'us' is the official short notation for micro seconds