### PR TITLE
Add asynchronous copy

### DIFF
--- a/platforms/artic/runtime.impala
+++ b/platforms/artic/runtime.impala
@@ -6,6 +6,7 @@
 #[import(cc = "C", name = "anydsl_alloc_host")]     fn runtime_alloc_host(_device: i32, _size: i64) -> &mut [i8];
 #[import(cc = "C", name = "anydsl_alloc_unified")]  fn runtime_alloc_unified(_device: i32, _size: i64) -> &mut [i8];
 #[import(cc = "C", name = "anydsl_copy")]           fn runtime_copy(_src_device: i32, _src_ptr: &[i8], _src_offset: i64, _dst_device: i32, _dst_ptr: &mut [i8], _dst_offset: i64, _size: i64) -> ();
+#[import(cc = "C", name = "anydsl_copy_async")]     fn runtime_copy_async(_src_device: i32, _src_ptr: &[i8], _src_offset: i64, _dst_device: i32, _dst_ptr: &mut [i8], _dst_offset: i64, _size: i64) -> ();
 #[import(cc = "C", name = "anydsl_get_device_ptr")] fn runtime_get_device_ptr(_device: i32, _ptr: &[i8]) -> &[i8];
 #[import(cc = "C", name = "anydsl_synchronize")]    fn runtime_synchronize(_device: i32) -> ();
 #[import(cc = "C", name = "anydsl_release")]        fn runtime_release(_device: i32, _ptr: &[i8]) -> ();
@@ -114,6 +115,8 @@ fn @synchronize_hsa(dev: i32) = runtime_synchronize(runtime_device(3, dev));
 
 fn @copy(src: Buffer, dst: Buffer) = runtime_copy(src.device, src.data, 0, dst.device, dst.data, 0, src.size);
 fn @copy_offset(src: Buffer, off_src: i64, dst: Buffer, off_dst: i64, size: i64) = runtime_copy(src.device, src.data, off_src, dst.device, dst.data, off_dst, size);
+fn @copy_async(src: Buffer, dst: Buffer) = runtime_copy_async(src.device, src.data, 0, dst.device, dst.data, 0, src.size);
+fn @copy_offset_async(src: Buffer, off_src: i64, dst: Buffer, off_dst: i64, size: i64) = runtime_copy_async(src.device, src.data, off_src, dst.device, dst.data, off_dst, size);
 
 
 // range, range_step, unroll, unroll_step, etc.

--- a/platforms/impala/runtime.impala
+++ b/platforms/impala/runtime.impala
@@ -7,6 +7,7 @@ extern "C" {
     fn "anydsl_alloc_host"     runtime_alloc_host(i32, i64) -> &[i8];
     fn "anydsl_alloc_unified"  runtime_alloc_unified(i32, i64) -> &[i8];
     fn "anydsl_copy"           runtime_copy(i32, &[i8], i64, i32, &[i8], i64, i64) -> ();
+    fn "anydsl_copy_async"     runtime_copy_async(i32, &[i8], i64, i32, &[i8], i64, i64) -> ();
     fn "anydsl_get_device_ptr" runtime_get_device_ptr(i32, &[i8]) -> &[i8];
     fn "anydsl_release"        runtime_release(i32, &[i8]) -> ();
     fn "anydsl_release_host"   runtime_release_host(i32, &[i8]) -> ();
@@ -86,6 +87,14 @@ fn @copy(src: Buffer, dst: Buffer) -> () {
 
 fn @copy_offset(src: Buffer, off_src: i64, dst: Buffer, off_dst: i64, size: i64) -> () {
     runtime_copy(src.device, src.data, off_src, dst.device, dst.data, off_dst, size)
+}
+
+fn @copy_async(src: Buffer, dst: Buffer) -> () {
+    runtime_copy_async(src.device, src.data, 0i64, dst.device, dst.data, 0i64, src.size)
+}
+
+fn @copy_offset_async(src: Buffer, off_src: i64, dst: Buffer, off_dst: i64, size: i64) -> () {
+    runtime_copy_async(src.device, src.data, off_src, dst.device, dst.data, off_dst, size)
 }
 
 

--- a/src/anydsl_runtime.cpp
+++ b/src/anydsl_runtime.cpp
@@ -111,7 +111,15 @@ void anydsl_copy(
     int32_t mask_dst, void* dst, int64_t offset_dst, int64_t size) {
     runtime().copy(
         to_platform(mask_src), to_device(mask_src), src, offset_src,
-        to_platform(mask_dst), to_device(mask_dst), dst, offset_dst, size);
+        to_platform(mask_dst), to_device(mask_dst), dst, offset_dst, size, false);
+}
+
+void anydsl_copy_async(
+    int32_t mask_src, const void* src, int64_t offset_src,
+    int32_t mask_dst, void* dst, int64_t offset_dst, int64_t size) {
+    runtime().copy(
+        to_platform(mask_src), to_device(mask_src), src, offset_src,
+        to_platform(mask_dst), to_device(mask_dst), dst, offset_dst, size, true);
 }
 
 void anydsl_launch_kernel(

--- a/src/anydsl_runtime.h
+++ b/src/anydsl_runtime.h
@@ -32,6 +32,7 @@ AnyDSL_runtime_API void  anydsl_release(int32_t, void*);
 AnyDSL_runtime_API void  anydsl_release_host(int32_t, void*);
 
 AnyDSL_runtime_API void anydsl_copy(int32_t, const void*, int64_t, int32_t, void*, int64_t, int64_t);
+AnyDSL_runtime_API void anydsl_copy_async(int32_t, const void*, int64_t, int32_t, void*, int64_t, int64_t);
 
 AnyDSL_runtime_API void anydsl_launch_kernel(
     int32_t, const char*, const char*,

--- a/src/anydsl_runtime.hpp
+++ b/src/anydsl_runtime.hpp
@@ -123,6 +123,27 @@ void copy(const Array<T>& a, int64_t offset_a, Array<T>& b, int64_t offset_b, in
                 size * sizeof(T));
 }
 
+template <typename T>
+void copy_async(const Array<T>& a, Array<T>& b) {
+    anydsl_copy_async(a.device(), (const void*)a.data(), 0,
+                b.device(), (void*)b.data(), 0,
+                a.size() * sizeof(T));
+}
+
+template <typename T>
+void copy_async(const Array<T>& a, Array<T>& b, int64_t size) {
+    anydsl_copy_async(a.device(), (const void*)a.data(), 0,
+                b.device(), (void*)b.data(), 0,
+                size * sizeof(T));
+}
+
+template <typename T>
+void copy_async(const Array<T>& a, int64_t offset_a, Array<T>& b, int64_t offset_b, int64_t size) {
+    anydsl_copy_async(a.device(), (const void*)a.data(), offset_a * sizeof(T),
+                b.device(), (void*)b.data(), offset_b * sizeof(T),
+                size * sizeof(T));
+}
+
 } // namespace anydsl
 
 #endif

--- a/src/cpu_platform.h
+++ b/src/cpu_platform.h
@@ -51,15 +51,17 @@ protected:
     }
 
     void copy(DeviceId, const void* src, int64_t offset_src,
-              DeviceId, void* dst, int64_t offset_dst, int64_t size) override {
+              DeviceId, void* dst, int64_t offset_dst, int64_t size, bool) override {
         copy(src, offset_src, dst, offset_dst, size);
     }
+
     void copy_from_host(const void* src, int64_t offset_src, DeviceId,
-                        void* dst, int64_t offset_dst, int64_t size) override {
+                        void* dst, int64_t offset_dst, int64_t size, bool) override {
         copy(src, offset_src, dst, offset_dst, size);
     }
+
     void copy_to_host(DeviceId, const void* src, int64_t offset_src,
-                      void* dst, int64_t offset_dst, int64_t size) override {
+                      void* dst, int64_t offset_dst, int64_t size, bool) override {
         copy(src, offset_src, dst, offset_dst, size);
     }
 

--- a/src/cuda_platform.h
+++ b/src/cuda_platform.h
@@ -40,9 +40,9 @@ protected:
     void launch_kernel(DeviceId dev, const LaunchParams& launch_params) override;
     void synchronize(DeviceId dev) override;
 
-    void copy(DeviceId dev_src, const void* src, int64_t offset_src, DeviceId dev_dst, void* dst, int64_t offset_dst, int64_t size) override;
-    void copy_from_host(const void* src, int64_t offset_src, DeviceId dev_dst, void* dst, int64_t offset_dst, int64_t size) override;
-    void copy_to_host(DeviceId dev_src, const void* src, int64_t offset_src, void* dst, int64_t offset_dst, int64_t size) override;
+    void copy(DeviceId dev_src, const void* src, int64_t offset_src, DeviceId dev_dst, void* dst, int64_t offset_dst, int64_t size, bool hint_async) override;
+    void copy_from_host(const void* src, int64_t offset_src, DeviceId dev_dst, void* dst, int64_t offset_dst, int64_t size, bool hint_async) override;
+    void copy_to_host(DeviceId dev_src, const void* src, int64_t offset_src, void* dst, int64_t offset_dst, int64_t size, bool hint_async) override;
 
     size_t dev_count() const override { return devices_.size(); }
     std::string name() const override { return "CUDA"; }

--- a/src/dummy_platform.h
+++ b/src/dummy_platform.h
@@ -24,9 +24,9 @@ protected:
     void launch_kernel(DeviceId, const LaunchParams&) override { platform_error(); }
     void synchronize(DeviceId) override { platform_error(); }
 
-    void copy(DeviceId, const void*, int64_t, DeviceId, void*, int64_t, int64_t) override { platform_error(); }
-    void copy_from_host(const void*, int64_t, DeviceId, void*, int64_t, int64_t) override { platform_error(); }
-    void copy_to_host(DeviceId, const void*, int64_t, void*, int64_t, int64_t) override { platform_error(); }
+    void copy(DeviceId, const void*, int64_t, DeviceId, void*, int64_t, int64_t, bool) override { platform_error(); }
+    void copy_from_host(const void*, int64_t, DeviceId, void*, int64_t, int64_t, bool) override { platform_error(); }
+    void copy_to_host(DeviceId, const void*, int64_t, void*, int64_t, int64_t, bool) override { platform_error(); }
 
     size_t dev_count() const override { return 0; }
     std::string name() const override { return name_; }

--- a/src/hsa_platform.cpp
+++ b/src/hsa_platform.cpp
@@ -443,7 +443,9 @@ void HSAPlatform::synchronize(DeviceId dev) {
         error("HSA signal completion failed: %", completion);
 }
 
-void HSAPlatform::copy(const void* src, int64_t offset_src, void* dst, int64_t offset_dst, int64_t size) {
+void HSAPlatform::copy(const void* src, int64_t offset_src, void* dst, int64_t offset_dst, int64_t size, bool hint_async) {
+    unused(hint_async);
+
     hsa_status_t status = hsa_memory_copy((char*)dst + offset_dst, (char*)src + offset_src, size);
     CHECK_HSA(status, "hsa_memory_copy()");
 }

--- a/src/hsa_platform.h
+++ b/src/hsa_platform.h
@@ -33,10 +33,10 @@ protected:
     void launch_kernel(DeviceId dev, const LaunchParams& launch_params) override;
     void synchronize(DeviceId dev) override;
 
-    void copy(const void* src, int64_t offset_src, void* dst, int64_t offset_dst, int64_t size);
-    void copy(DeviceId, const void* src, int64_t offset_src, DeviceId, void* dst, int64_t offset_dst, int64_t size) override { copy(src, offset_src, dst, offset_dst, size); }
-    void copy_from_host(const void* src, int64_t offset_src, DeviceId, void* dst, int64_t offset_dst, int64_t size) override { copy(src, offset_src, dst, offset_dst, size); }
-    void copy_to_host(DeviceId, const void* src, int64_t offset_src, void* dst, int64_t offset_dst, int64_t size) override { copy(src, offset_src, dst, offset_dst, size); }
+    void copy(const void* src, int64_t offset_src, void* dst, int64_t offset_dst, int64_t size, bool hint_async);
+    void copy(DeviceId, const void* src, int64_t offset_src, DeviceId, void* dst, int64_t offset_dst, int64_t size, bool hint_async) override { copy(src, offset_src, dst, offset_dst, size, hint_async); }
+    void copy_from_host(const void* src, int64_t offset_src, DeviceId, void* dst, int64_t offset_dst, int64_t size, bool hint_async) override { copy(src, offset_src, dst, offset_dst, size, hint_async); }
+    void copy_to_host(DeviceId, const void* src, int64_t offset_src, void* dst, int64_t offset_dst, int64_t size, bool hint_async) override { copy(src, offset_src, dst, offset_dst, size, hint_async); }
 
     size_t dev_count() const override { return devices_.size(); }
     std::string name() const override { return "HSA"; }

--- a/src/opencl_platform.h
+++ b/src/opencl_platform.h
@@ -34,9 +34,10 @@ protected:
     void launch_kernel(DeviceId dev, const LaunchParams& launch_params) override;
     void synchronize(DeviceId dev) override;
 
-    void copy(DeviceId dev_src, const void* src, int64_t offset_src, DeviceId dev_dst, void* dst, int64_t offset_dst, int64_t size) override;
-    void copy_from_host(const void* src, int64_t offset_src, DeviceId dev_dst, void* dst, int64_t offset_dst, int64_t size) override;
-    void copy_to_host(DeviceId dev_src, const void* src, int64_t offset_src, void* dst, int64_t offset_dst, int64_t size) override;
+    void copy(DeviceId dev_src, const void* src, int64_t offset_src, DeviceId dev_dst, void* dst, int64_t offset_dst, int64_t size, bool hint_async) override;
+    void copy_from_host(const void* src, int64_t offset_src, DeviceId dev_dst, void* dst, int64_t offset_dst, int64_t size, bool hint_async) override;
+    void copy_to_host(DeviceId dev_src, const void* src, int64_t offset_src, void* dst, int64_t offset_dst, int64_t size, bool hint_async) override;
+
     void copy_svm(const void* src, int64_t offset_src, void* dst, int64_t offset_dst, int64_t size);
     void dynamic_profile(DeviceId dev, const std::string& filename);
 

--- a/src/platform.h
+++ b/src/platform.h
@@ -42,11 +42,11 @@ public:
     virtual void synchronize(DeviceId dev) = 0;
 
     /// Copies memory. Copy can only be performed devices in the same platform.
-    virtual void copy(DeviceId dev_src, const void* src, int64_t offset_src, DeviceId dev_dst, void* dst, int64_t offset_dst, int64_t size) = 0;
+    virtual void copy(DeviceId dev_src, const void* src, int64_t offset_src, DeviceId dev_dst, void* dst, int64_t offset_dst, int64_t size, bool hint_async) = 0;
     /// Copies memory from the host (CPU).
-    virtual void copy_from_host(const void* src, int64_t offset_src, DeviceId dev_dst, void* dst, int64_t offset_dst, int64_t size) = 0;
+    virtual void copy_from_host(const void* src, int64_t offset_src, DeviceId dev_dst, void* dst, int64_t offset_dst, int64_t size, bool hint_async) = 0;
     /// Copies memory to the host (CPU).
-    virtual void copy_to_host(DeviceId dev_src, const void* src, int64_t offset_src, void* dst, int64_t offset_dst, int64_t size) = 0;
+    virtual void copy_to_host(DeviceId dev_src, const void* src, int64_t offset_src, void* dst, int64_t offset_dst, int64_t size, bool hint_async) = 0;
 
     /// Returns the platform name.
     virtual std::string name() const = 0;

--- a/src/runtime.cpp
+++ b/src/runtime.cpp
@@ -74,22 +74,23 @@ void Runtime::release_host(PlatformId plat, DeviceId dev, void* ptr) {
 
 void Runtime::copy(
     PlatformId plat_src, DeviceId dev_src, const void* src, int64_t offset_src,
-    PlatformId plat_dst, DeviceId dev_dst, void* dst, int64_t offset_dst, int64_t size) {
+    PlatformId plat_dst, DeviceId dev_dst, void* dst, int64_t offset_dst, int64_t size,
+    bool hint_async) {
     check_device(plat_src, dev_src);
     check_device(plat_dst, dev_dst);
     if (plat_src == plat_dst) {
         // Copy from same platform
-        platforms_[plat_src]->copy(dev_src, src, offset_src, dev_dst, dst, offset_dst, size);
+        platforms_[plat_src]->copy(dev_src, src, offset_src, dev_dst, dst, offset_dst, size, hint_async);
         debug("Copy between devices % and % on platform %", dev_src, dev_dst, plat_src);
     } else {
         // Copy from another platform
         if (plat_src == 0) {
             // Source is the CPU platform
-            platforms_[plat_dst]->copy_from_host(src, offset_src, dev_dst, dst, offset_dst, size);
+            platforms_[plat_dst]->copy_from_host(src, offset_src, dev_dst, dst, offset_dst, size, hint_async);
             debug("Copy from host to device % on platform %", dev_dst, plat_dst);
         } else if (plat_dst == 0) {
             // Destination is the CPU platform
-            platforms_[plat_src]->copy_to_host(dev_src, src, offset_src, dst, offset_dst, size);
+            platforms_[plat_src]->copy_to_host(dev_src, src, offset_src, dst, offset_dst, size, hint_async);
             debug("Copy to host from device % on platform %", dev_src, plat_src);
         } else {
             error("Cannot copy memory between different platforms");

--- a/src/runtime.h
+++ b/src/runtime.h
@@ -70,7 +70,8 @@ public:
     /// Copies memory between devices.
     void copy(
         PlatformId plat_src, DeviceId dev_src, const void* src, int64_t offset_src,
-        PlatformId plat_dst, DeviceId dev_dst, void* dst, int64_t offset_dst, int64_t size);
+        PlatformId plat_dst, DeviceId dev_dst, void* dst, int64_t offset_dst, int64_t size,
+        bool hint_async = false);
 
     /// Launches a kernel on the platform and device.
     void launch_kernel(PlatformId plat, DeviceId dev, const LaunchParams& launch_params);


### PR DESCRIPTION
Add asynchronous copy operation `anydsl_copy_async`.

The "async" is only a hint and only works on CUDA and OpenCL. Did not find a suitable method for HSA. 
CPU could have async, but usually the host is handled as a single unit without async capabilities, therefore it was not added intentionally.

Tested with Rodent (Artic).