### PR TITLE
Add PAL-based backend for AMD GPUs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,3 @@
 build*
+
+.vscode

--- a/CONTRIBUTORS.txt
+++ b/CONTRIBUTORS.txt
@@ -1,16 +1,5 @@
 # This is the official list of contributing authors in the AnyDSL runtime project for copyright purposes.
-#
-# Names should be added to this file as:
-#     Name, github handle(s) [, Email]
-# The github handle(s) are those under which the person contributed to this project.
-# The email address is not required.
-# 
-# If an organization is the copyright holder, authors of that organization must be listed with the organization association:
-#          Name, Organization, github handle(s) [, Email]
-#
-# Please keep the list sorted.
 
-
-Fabian Wildgrube, AMD, @FabianWildgrube, fabian.wildgrube@amd.com
-
-TODO: add other contributors from THI, Uni Saarland, etc.
+# Name, GitHub Handle, Affiliation
+Fabian Wildgrube, FabianWildgrube, Advanced Micro Devices Inc.
+# TODO: add other contributors from THI, Uni Saarland, etc.

--- a/CONTRIBUTORS.txt
+++ b/CONTRIBUTORS.txt
@@ -1,0 +1,16 @@
+# This is the official list of contributing authors in the AnyDSL runtime project for copyright purposes.
+#
+# Names should be added to this file as:
+#     Name, github handle(s) [, Email]
+# The github handle(s) are those under which the person contributed to this project.
+# The email address is not required.
+# 
+# If an organization is the copyright holder, authors of that organization must be listed with the organization association:
+#          Name, Organization, github handle(s) [, Email]
+#
+# Please keep the list sorted.
+
+
+Fabian Wildgrube, AMD, @FabianWildgrube, fabian.wildgrube@amd.com
+
+TODO: add other contributors from THI, Uni Saarland, etc.

--- a/cmake/anydsl_runtime-config.cmake.in
+++ b/cmake/anydsl_runtime-config.cmake.in
@@ -98,6 +98,7 @@ find_package(LLVM CONFIG QUIET PATHS ${LLVM_DIR} $ENV{LLVM_DIR} "@LLVM_DIR@" NO_
 set(AnyDSL_runtime_HAS_CUDA_SUPPORT    @AnyDSL_runtime_HAS_CUDA_SUPPORT@)
 set(AnyDSL_runtime_HAS_OPENCL_SUPPORT  @AnyDSL_runtime_HAS_OPENCL_SUPPORT@)
 set(AnyDSL_runtime_HAS_HSA_SUPPORT     @AnyDSL_runtime_HAS_HSA_SUPPORT@)
+set(AnyDSL_runtime_HAS_PAL_SUPPORT     @AnyDSL_runtime_HAS_PAL_SUPPORT@)
 set(AnyDSL_runtime_HAS_TBB_SUPPORT     @AnyDSL_runtime_HAS_TBB_SUPPORT@)
 set(AnyDSL_runtime_HAS_LLVM_SUPPORT    @AnyDSL_runtime_HAS_LLVM_SUPPORT@)
 set(AnyDSL_runtime_HAS_JIT_SUPPORT     @AnyDSL_runtime_HAS_JIT_SUPPORT@)

--- a/platforms/artic/intrinsics_amdgpu.impala
+++ b/platforms/artic/intrinsics_amdgpu.impala
@@ -4,6 +4,8 @@
 #[import(cc = "device", name = "llvm.amdgcn.ds.gws.barrier")]       fn amdgcn_ds_gws_barrier(i32, i32) -> ();
 #[import(cc = "device", name = "llvm.amdgcn.s.barrier")]            fn amdgcn_s_barrier() -> ();
 #[import(cc = "device", name = "llvm.amdgcn.wave.barrier")]         fn amdgcn_wave_barrier() -> ();
+#[import(cc = "device", name = "llvm.amdgcn.sched.barrier")]        fn amdgcn_sched_barrier(i32) -> ();
+#[import(cc = "device", name = "llvm.amdgcn.s.sethalt")]            fn amdgcn_s_sethalt(i32) -> ();
 #[import(cc = "device", name = "llvm.amdgcn.wavefrontsize")]        fn amdgcn_wavefrontsize() -> i32;
 #[import(cc = "device", name = "llvm.amdgcn.mbcnt.hi")]             fn amdgcn_mbcnt_hi(i32, i32) -> i32;
 #[import(cc = "device", name = "llvm.amdgcn.mbcnt.lo")]             fn amdgcn_mbcnt_lo(i32, i32) -> i32;
@@ -302,6 +304,12 @@ fn @amdgcn_maxmax(a: i32, b: i32, c: i32) -> i32 {
     res
 }
 
+fn @amdpal_breakpoint() -> () {
+    amdgcn_sched_barrier(0);
+    amdgcn_s_sethalt(1);
+    amdgcn_sched_barrier(0);
+}
+
 struct hsa_signal_t {
     handle : u64
 }
@@ -324,7 +332,7 @@ struct hsa_dispatch_packet_t {
     completion_signal : hsa_signal_t
 }
 
-fn @amdgpu_accelerator(dev: i32) = Accelerator {
+fn @amdgpu_hsa_accelerator(dev: i32) = Accelerator {
     exec = @|body| |grid, block| {
         fn @div_round_up(num: i32, multiple: i32) -> i32 { (num + multiple - 1) / multiple }
         let work_item = WorkItem {
@@ -347,11 +355,54 @@ fn @amdgpu_accelerator(dev: i32) = Accelerator {
             nblky = @|| div_round_up(bitcast[&addrspace(4)[u32]](amdgcn_dispatch_ptr())(4) as i32, bitcast[&addrspace(4)[u16]](amdgcn_dispatch_ptr())(3) as i32),
             nblkz = @|| div_round_up(bitcast[&addrspace(4)[u32]](amdgcn_dispatch_ptr())(5) as i32, bitcast[&addrspace(4)[u16]](amdgcn_dispatch_ptr())(4) as i32)
         };
-        amdgpu(dev, grid, block, || @body(work_item))
+        amdgpu_hsa(dev, grid, block, || @body(work_item))
     },
     sync          = @|| synchronize_hsa(dev),
     alloc         = @|size| alloc_hsa(dev, size),
     alloc_unified = @|size| alloc_hsa_unified(dev, size),
+    barrier       = amdgcn_s_barrier,
+};
+
+#[import(cc = "device", name = "anydsl.amdpal.workitem.id.x")]        fn amdpal_workitem_id_x() -> i32;
+#[import(cc = "device", name = "anydsl.amdpal.workitem.id.y")]        fn amdpal_workitem_id_y() -> i32;
+#[import(cc = "device", name = "anydsl.amdpal.workitem.id.z")]        fn amdpal_workitem_id_z() -> i32;
+#[import(cc = "device", name = "anydsl.amdpal.workgroup.id.x")]       fn amdpal_workgroup_id_x() -> i32;
+#[import(cc = "device", name = "anydsl.amdpal.workgroup.id.y")]       fn amdpal_workgroup_id_y() -> i32;
+#[import(cc = "device", name = "anydsl.amdpal.workgroup.id.z")]       fn amdpal_workgroup_id_z() -> i32;
+#[import(cc = "device", name = "anydsl.amdpal.workgroup.size.x")]     fn amdpal_workgroup_size_x() -> i32;
+#[import(cc = "device", name = "anydsl.amdpal.workgroup.size.y")]     fn amdpal_workgroup_size_y() -> i32;
+#[import(cc = "device", name = "anydsl.amdpal.workgroup.size.z")]     fn amdpal_workgroup_size_z() -> i32;
+#[import(cc = "device", name = "anydsl.amdpal.nblk.x")]               fn amdpal_nblk_x() -> i32;
+#[import(cc = "device", name = "anydsl.amdpal.nblk.y")]               fn amdpal_nblk_y() -> i32;
+#[import(cc = "device", name = "anydsl.amdpal.nblk.z")]               fn amdpal_nblk_z() -> i32;
+
+fn @amdgpu_pal_accelerator(dev: i32) = Accelerator {
+    exec = @|body| |grid, block| {
+        let work_item = WorkItem {
+            tidx  = amdpal_workitem_id_x,
+            tidy  = amdpal_workitem_id_y,
+            tidz  = amdpal_workitem_id_z,
+            bidx  = amdpal_workgroup_id_x,
+            bidy  = amdpal_workgroup_id_y,
+            bidz  = amdpal_workgroup_id_z,
+            gidx  = @|| amdpal_workgroup_id_x() * amdpal_workgroup_size_x() + amdpal_workitem_id_x(),
+            gidy  = @|| amdpal_workgroup_id_y() * amdpal_workgroup_size_y() + amdpal_workitem_id_y(),
+            gidz  = @|| amdpal_workgroup_id_z() * amdpal_workgroup_size_z() + amdpal_workitem_id_z(),
+            bdimx = amdpal_workgroup_size_x,
+            bdimy = amdpal_workgroup_size_y,
+            bdimz = amdpal_workgroup_size_z,
+            gdimx = @|| amdpal_nblk_x() * amdpal_workgroup_size_x(),
+            gdimy = @|| amdpal_nblk_y() * amdpal_workgroup_size_y(),
+            gdimz = @|| amdpal_nblk_z() * amdpal_workgroup_size_z(),
+            nblkx = amdpal_nblk_x,
+            nblky = amdpal_nblk_y,
+            nblkz = amdpal_nblk_z
+        };
+        amdgpu_pal(dev, grid, block, || @body(work_item))
+    },
+    sync          = @|| synchronize_pal(dev),
+    alloc         = @|size| alloc_pal(dev, size),
+    alloc_unified = @|size| alloc_pal_unified(dev, size),
     barrier       = amdgcn_s_barrier,
 };
 

--- a/platforms/artic/intrinsics_thorin.impala
+++ b/platforms/artic/intrinsics_thorin.impala
@@ -15,7 +15,8 @@
 #[import(cc = "thorin")] fn cuda(_dev: i32, _grid: (i32, i32, i32), _block: (i32, i32, i32), _body: fn() -> ()) -> ();
 #[import(cc = "thorin")] fn nvvm(_dev: i32, _grid: (i32, i32, i32), _block: (i32, i32, i32), _body: fn() -> ()) -> ();
 #[import(cc = "thorin")] fn opencl(_dev: i32, _grid: (i32, i32, i32), _block: (i32, i32, i32), _body: fn() -> ()) -> ();
-#[import(cc = "thorin")] fn amdgpu(_dev: i32, _grid: (i32, i32, i32), _block: (i32, i32, i32), _body: fn() -> ()) -> ();
+#[import(cc = "thorin")] fn amdgpu_hsa(_dev: i32, _grid: (i32, i32, i32), _block: (i32, i32, i32), _body: fn() -> ()) -> ();
+#[import(cc = "thorin")] fn amdgpu_pal(_dev: i32, _grid: (i32, i32, i32), _block: (i32, i32, i32), _body: fn() -> ()) -> ();
 #[import(cc = "thorin")] fn reserve_shared[T](_size: i32) -> &mut addrspace(3)[T];
 #[import(cc = "thorin")] fn hls(_dev: i32, _body: fn() -> ()) -> ();
 #[import(cc = "thorin", name = "pipeline")] fn thorin_pipeline(_initiation_interval: i32, _lower: i32, _upper: i32, _body: fn(i32) -> ()) -> (); // only for HLS/OpenCL backend

--- a/platforms/artic/runtime.impala
+++ b/platforms/artic/runtime.impala
@@ -67,6 +67,10 @@
 //fn @alloc_hsa_host[T](dev: i32, size: i64) = alloc_host[T](runtime_device(3, dev), size);
 //fn @alloc_hsa_unified[T](dev: i32, size: i64) = alloc_unified[T](runtime_device(3, dev), size);
 //fn @synchronize_hsa(dev: i32) = runtime_synchronize(runtime_device(3, dev));
+//fn @alloc_pal[T](dev: i32, size: i64) = alloc[T](runtime_device(4, dev), size);
+//fn @alloc_pal_host[T](dev: i32, size: i64) = alloc_host[T](runtime_device(4, dev), size);
+//fn @alloc_pal_unified[T](dev: i32, size: i64) = alloc_unified[T](runtime_device(4, dev), size);
+//fn @synchronize_pal(dev: i32) = runtime_synchronize(runtime_device(4, dev));
 //
 //fn @copy[T](src: Buffer[T], dst: Buffer[T]) = runtime_copy(src.device, src.data as &[i8], 0, dst.device, dst.data as &mut [i8], 0, src.size);
 //fn @copy_offset[T](src: Buffer[T], off_src: i64, dst: Buffer[T], off_dst: i64, size: i64) = runtime_copy(src.device, src.data as &[i8], off_src, dst.device, dst.data as &mut [i8], off_dst, size);
@@ -111,6 +115,10 @@ fn @alloc_hsa(dev: i32, size: i64) = alloc(runtime_device(3, dev), size);
 fn @alloc_hsa_host(dev: i32, size: i64) = alloc_host(runtime_device(3, dev), size);
 fn @alloc_hsa_unified(dev: i32, size: i64) = alloc_unified(runtime_device(3, dev), size);
 fn @synchronize_hsa(dev: i32) = runtime_synchronize(runtime_device(3, dev));
+fn @alloc_pal(dev: i32, size: i64) = alloc(runtime_device(4, dev), size);
+fn @alloc_pal_host(dev: i32, size: i64) = alloc_host(runtime_device(4, dev), size);
+fn @alloc_pal_unified(dev: i32, size: i64) = alloc_unified(runtime_device(4, dev), size);
+fn @synchronize_pal(dev: i32) = runtime_synchronize(runtime_device(4, dev));
 
 fn @copy(src: Buffer, dst: Buffer) = runtime_copy(src.device, src.data, 0, dst.device, dst.data, 0, src.size);
 fn @copy_offset(src: Buffer, off_src: i64, dst: Buffer, off_dst: i64, size: i64) = runtime_copy(src.device, src.data, off_src, dst.device, dst.data, off_dst, size);

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -132,8 +132,13 @@ if(pal_FOUND)
     target_link_libraries(runtime_pal PRIVATE runtime_base pal::pal)
     list(APPEND RUNTIME_PLATFORMS runtime_pal)
 
-    cmake_path(GET CMAKE_SOURCE_DIR PARENT_PATH AnyDSL_metaproject_PATH)
-    cmake_path(SET AnyDSL_runtime_PAL_BITCODE_PATH NORMALIZE "${AnyDSL_metaproject_PATH}/rocm-device-libs/build/amdgcn/bitcode")
+    find_file(AnyDSL_runtime_ROCM_OCML_LIB
+        NAMES ocml.bc
+        HINTS ${CMAKE_SOURCE_DIR}/../rocm-device-libs
+        PATH_SUFFIXES build/amdgcn/bitcode
+        REQUIRED)
+    get_filename_component(AnyDSL_runtime_PAL_BITCODE_PATH ${AnyDSL_runtime_ROCM_OCML_LIB} DIRECTORY)
+    get_filename_component(AnyDSL_runtime_PAL_BITCODE_SUFFIX ${AnyDSL_runtime_ROCM_OCML_LIB} EXT)
 endif()
 set(AnyDSL_runtime_HAS_PAL_SUPPORT ${pal_FOUND} CACHE INTERNAL "enables PAL support")
 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -111,6 +111,32 @@ if(hsa-runtime64_FOUND)
 endif()
 set(AnyDSL_runtime_HAS_HSA_SUPPORT ${hsa-runtime64_FOUND} CACHE INTERNAL "enables HSA support")
 
+# look for PAL
+find_package(pal)
+if(pal_FOUND)
+    add_library(runtime_pal STATIC 
+        pal_platform.h
+        pal_platform.cpp
+        pal/pal_lower_kernel_arguments_pass.h
+        pal/pal_lower_kernel_arguments_pass.cpp
+        pal/pal_fix_calling_convention_pass.h
+        pal/pal_fix_calling_convention_pass.cpp
+        pal/pal_lower_builtins_pass.h
+        pal/pal_lower_builtins_pass.cpp
+        pal/pal_insert_halt_pass.h
+        pal/pal_insert_halt_pass.cpp
+        pal/pal_utils.h
+        pal/pal_utils.cpp
+        pal/pal_device.h
+        pal/pal_device.cpp)
+    target_link_libraries(runtime_pal PRIVATE runtime_base pal::pal)
+    list(APPEND RUNTIME_PLATFORMS runtime_pal)
+
+    cmake_path(GET CMAKE_SOURCE_DIR PARENT_PATH AnyDSL_metaproject_PATH)
+    cmake_path(SET AnyDSL_runtime_PAL_BITCODE_PATH NORMALIZE "${AnyDSL_metaproject_PATH}/rocm-device-libs/build/amdgcn/bitcode")
+endif()
+set(AnyDSL_runtime_HAS_PAL_SUPPORT ${pal_FOUND} CACHE INTERNAL "enables PAL support")
+
 # look for LLVM for nvptx and gcn
 find_package(LLVM)
 if(LLVM_FOUND)
@@ -127,6 +153,11 @@ if(LLVM_FOUND)
         find_package(LLD REQUIRED)
         target_link_libraries(runtime_hsa PRIVATE lldELF lldCommon)
         llvm_config(runtime_hsa ${AnyDSL_LLVM_LINK_SHARED} lto option ${LLVM_TARGETS_TO_BUILD})
+    endif()
+    if(AnyDSL_runtime_HAS_PAL_SUPPORT)
+        find_package(LLD REQUIRED)
+        target_link_libraries(runtime_pal PRIVATE lldELF lldCommon)
+        llvm_config(runtime_pal ${AnyDSL_LLVM_LINK_SHARED} lto option ${LLVM_TARGETS_TO_BUILD})
     endif()
 endif()
 set(AnyDSL_runtime_HAS_LLVM_SUPPORT ${LLVM_FOUND} CACHE INTERNAL "enables nvptx / gcn support")

--- a/src/anydsl_runtime.cpp
+++ b/src/anydsl_runtime.cpp
@@ -35,6 +35,7 @@ struct RuntimeSingleton {
         register_cuda_platform(&runtime);
         register_opencl_platform(&runtime);
         register_hsa_platform(&runtime);
+        register_pal_platform(&runtime);
     }
 
     static std::pair<ProfileLevel, ProfileLevel> detect_profile_level() {

--- a/src/anydsl_runtime.h
+++ b/src/anydsl_runtime.h
@@ -16,7 +16,8 @@ enum {
     ANYDSL_HOST = 0,
     ANYDSL_CUDA = 1,
     ANYDSL_OPENCL = 2,
-    ANYDSL_HSA = 3
+    ANYDSL_HSA = 3,
+    ANYDSL_PAL = 4
 };
 
 AnyDSL_runtime_API void anydsl_info(void);

--- a/src/anydsl_runtime.hpp
+++ b/src/anydsl_runtime.hpp
@@ -11,7 +11,8 @@ enum class Platform : int32_t {
     Host = ANYDSL_HOST,
     Cuda = ANYDSL_CUDA,
     OpenCL = ANYDSL_OPENCL,
-    HSA = ANYDSL_HSA
+    HSA = ANYDSL_HSA,
+    PAL = ANYDSL_PAL
 };
 
 struct Device {

--- a/src/anydsl_runtime_config.h.in
+++ b/src/anydsl_runtime_config.h.in
@@ -48,13 +48,14 @@
 #define AnyDSL_runtime_HSA_BITCODE_PATH     "@AnyDSL_runtime_HSA_BITCODE_PATH@/"
 #define AnyDSL_runtime_HSA_BITCODE_SUFFIX   "@AnyDSL_runtime_HSA_BITCODE_SUFFIX@"
 
-// jit support
-
-#define AnyDSL_runtime_SOURCE_DIR           "@CMAKE_CURRENT_SOURCE_DIR@"
-
 // PAL support
 
 #define AnyDSL_runtime_PAL_BITCODE_PATH     "@AnyDSL_runtime_PAL_BITCODE_PATH@/"
+#define AnyDSL_runtime_PAL_BITCODE_SUFFIX   "@AnyDSL_runtime_PAL_BITCODE_SUFFIX@"
+
+// jit support
+
+#define AnyDSL_runtime_SOURCE_DIR           "@CMAKE_CURRENT_SOURCE_DIR@"
 
 // debug output
 

--- a/src/anydsl_runtime_config.h.in
+++ b/src/anydsl_runtime_config.h.in
@@ -9,6 +9,7 @@
 #cmakedefine AnyDSL_runtime_HAS_CUDA_SUPPORT
 #cmakedefine AnyDSL_runtime_HAS_OPENCL_SUPPORT
 #cmakedefine AnyDSL_runtime_HAS_HSA_SUPPORT
+#cmakedefine AnyDSL_runtime_HAS_PAL_SUPPORT
 #cmakedefine AnyDSL_runtime_HAS_TBB_SUPPORT
 
 
@@ -51,6 +52,9 @@
 
 #define AnyDSL_runtime_SOURCE_DIR           "@CMAKE_CURRENT_SOURCE_DIR@"
 
+// PAL support
+
+#define AnyDSL_runtime_PAL_BITCODE_PATH     "@AnyDSL_runtime_PAL_BITCODE_PATH@/"
 
 // debug output
 

--- a/src/hsa_platform.h
+++ b/src/hsa_platform.h
@@ -9,8 +9,8 @@
 #include <unordered_map>
 #include <vector>
 
-#include <hsa.h>
-#include <hsa_ext_amd.h>
+#include <hsa/hsa.h>
+#include <hsa/hsa_ext_amd.h>
 
 namespace llvm {
 class OptimizationLevel;

--- a/src/pal/pal_device.cpp
+++ b/src/pal/pal_device.cpp
@@ -463,6 +463,11 @@ void PalDevice::dispatch(const Pal::CmdBufferBuildInfo& cmd_buffer_build_info,
     }
 }
 
+void PalDevice::WaitIdle() {
+    CHECK_PAL(queue_->WaitIdle(), "queue_->WaitIdle()");
+    CHECK_PAL(dma_queue_->WaitIdle(), "dma_queue_->WaitIdle()");
+}
+
 PalDevice::GpuVirtAddr_t PalDevice::write_data_to_gpu(
     Pal::gpusize byte_size, std::function<void(void*)> write_callback) {
     PalDevice::GpuVirtAddr_t gpu_only_buffer =

--- a/src/pal/pal_device.cpp
+++ b/src/pal/pal_device.cpp
@@ -1,0 +1,478 @@
+// Copyright (c) 2023 Advanced Micro Devices, Inc. All rights reserved.
+
+#include "pal_device.h"
+#include "pal_utils.h"
+
+#include "../log.h"
+
+constexpr const PalDevice::GpuVirtAddr_t nulladdr = 0;
+
+inline void check_pal_error(Pal::Result err, const char* name, const char* file, const int line) {
+    if (err != Pal::Result::Success) {
+        error("PAL API function % [file %, line %]: %", name, file, line, static_cast<int32_t>(err));
+    }
+}
+
+void pal_destroy(Pal::IDestroyable* object) {
+    assert(object != nullptr);
+    object->Destroy();
+    free(object);
+}
+
+PalDevice::PalDevice(Pal::IDevice* base_device)
+    : device_(base_device) {
+    Pal::Result result = init();
+    CHECK_PAL(result, "init pal device");
+
+    result = init_cmd_allocator();
+    CHECK_PAL(result, "pal_init_cmd_allocator()");
+
+    result = init_queue_and_cmd_buffer(queue_and_cmd_buffer_type::Compute);
+    CHECK_PAL(result, "pal_init_queue_and_cmd_buffer()");
+
+    Pal::DeviceProperties device_properties;
+    CHECK_PAL(device_->GetProperties(&device_properties), "device->GetProperties()");
+
+    gfx_level = device_properties.gfxLevel;
+    isa = pal_utils::get_gfx_isa_id(device_properties.gfxLevel);
+    name = pal_utils::get_gpu_name(device_properties.revision);
+}
+
+Pal::Result PalDevice::init() {
+    // Query properties for the selected GPU.
+    Pal::DeviceProperties device_properties = {};
+    Pal::Result result = device_->GetProperties(&device_properties);
+    CHECK_PAL(result, "GetProperties()");
+
+    if (device_properties.engineProperties[Pal::QueueTypeUniversal].engineCount < 1) {
+        // AnyDSL assumes a universal engine is available.
+        result = Pal::Result::ErrorUnavailable;
+    }
+
+    if (device_properties.engineProperties[Pal::QueueTypeCompute].engineCount < 1) {
+        // AnyDSL assumes a compute engine is available.
+        result = Pal::Result::ErrorUnavailable;
+    }
+
+    // At this point, we could configure PAL's behavior for this device:
+    // Pal::PalPublicSettings* const settings = device_->GetPublicSettings();
+    // ... modify the settings
+    // Commit the settings change(s) we've made and perform initialization on the IDevice object.
+    result = device_->CommitSettingsAndInit();
+    CHECK_PAL(result, "CommitSettingsAndInit()");
+
+    // Finalize is the final step of device initialization.  It must be called
+    // after CommitSettingsAndInit().
+    Pal::DeviceFinalizeInfo finalize_info = {};
+
+    // The universal queue allows graphics, compute, and copy operations, and
+    // corresponds to the hardware "graphics ring".
+    // Request one universal queue.
+    finalize_info.requestedEngineCounts[Pal::EngineTypeUniversal].engines = 1;
+
+    // And request one compute queue.
+    finalize_info.requestedEngineCounts[Pal::EngineTypeCompute].engines = 1;
+
+    result = device_->Finalize(finalize_info);
+    CHECK_PAL(result, "Finalize()");
+
+    return result;
+}
+
+PalDevice::~PalDevice() {
+    static_assert(Pal::GpuHeapCount == 4, "Destroy code needs an update if GpuHeapCount != 4.");
+
+    // Ensure the GPU is idle before destroying any objects.
+    if (queue_ != nullptr) {
+        queue_->WaitIdle();
+    }
+
+    // Destroy any IObject or IDestroyable objects and free their corresponding system memory.
+    pal_destroy(cmd_buffer_);
+    pal_destroy(queue_);
+    pal_destroy(cmd_allocator_);
+    for (auto& [_, pipeline] : programs_) {
+        pal_destroy(pipeline);
+    }
+    for (auto& [_, memory] : memory_objects_) {
+        pal_destroy(memory);
+    }
+    device_->Cleanup();
+
+    // The device is created by the platform, it does not need to be freed at
+    // all, but we should no longer maintain a pointer to it.
+    device_ = nullptr;
+}
+
+Pal::IPipeline* PalDevice::create_pipeline(const void* elf_data, size_t elf_data_size) {
+    Pal::ComputePipelineCreateInfo pipeline_info = {};
+
+    // Populate the info.
+    pipeline_info.pipelineBinarySize = elf_data_size;
+    pipeline_info.pPipelineBinary = elf_data;
+
+    Pal::Result result = Pal::Result::ErrorUnknown;
+    std::size_t pipeline_size = device_->GetComputePipelineSize(pipeline_info, &result);
+    CHECK_PAL(result, "GetComputePipelineSize()");
+
+    Pal::IPipeline* pipeline = nullptr;
+    void* pipe_line_space = malloc(pipeline_size);
+    result = device_->CreateComputePipeline(pipeline_info, pipe_line_space, &pipeline);
+    CHECK_PAL(result, "CreateComputePipeline()");
+    assert(pipe_line_space == pipeline);
+
+    return pipeline;
+}
+
+Pal::Result PalDevice::init_cmd_allocator() {
+    Pal::CmdAllocatorCreateInfo allocator_create_info = {};
+    allocator_create_info.flags.threadSafe = 1;
+    allocator_create_info.flags.autoMemoryReuse = 1;
+    // An allocator that uses 32, 64KB suballocations (2MB per base allocation) is
+    // a pretty reasonable configuration for universal command buffers. Clients
+    // may wish to use smaller sizes for DMA or compute specific allocators.
+    allocator_create_info.allocInfo[Pal::CommandDataAlloc].allocHeap = Pal::GpuHeapGartCacheable;
+    allocator_create_info.allocInfo[Pal::CommandDataAlloc].suballocSize = 64 * 1024;
+    allocator_create_info.allocInfo[Pal::CommandDataAlloc].allocSize =
+        (32 * allocator_create_info.allocInfo[Pal::CommandDataAlloc].suballocSize);
+    // For embedded data (which PAL uses internally), 32 4KB suballocations (128KB
+    // per base allocation) is a pretty reasonable configuration for universal
+    // command buffers. Clients may wish to use smaller sizes for DMA or compute
+    // specific allocators.
+    const Pal::gpusize embedded_data_suballocSize = 4 * 1024;
+    const Pal::gpusize embedded_data_allocSize = 32 * embedded_data_suballocSize;
+    allocator_create_info.allocInfo[Pal::EmbeddedDataAlloc].allocHeap = Pal::GpuHeapGartCacheable;
+    allocator_create_info.allocInfo[Pal::EmbeddedDataAlloc].suballocSize = embedded_data_suballocSize;
+    allocator_create_info.allocInfo[Pal::EmbeddedDataAlloc].allocSize = embedded_data_allocSize;
+    // For GPU-local scratch memory, use the same allocation size as embedded data.
+    allocator_create_info.allocInfo[Pal::GpuScratchMemAlloc].allocHeap = Pal::GpuHeapInvisible;
+    allocator_create_info.allocInfo[Pal::GpuScratchMemAlloc].suballocSize = embedded_data_suballocSize;
+    allocator_create_info.allocInfo[Pal::GpuScratchMemAlloc].allocSize = embedded_data_allocSize;
+
+    Pal::Result result  = Pal::Result::ErrorUnknown;
+    const size_t allocator_size = device_->GetCmdAllocatorSize(allocator_create_info, &result);
+
+    CHECK_PAL(result, "GetCmdAllocatorSize()");
+
+    result = device_->CreateCmdAllocator(allocator_create_info, malloc(allocator_size), &cmd_allocator_);
+
+    return result;
+}
+
+inline void ThrowIfFailed(Util::Result result, const std::string& message) {
+    if (Util::IsErrorResult(result)) {
+        error(message.c_str());
+    }
+}
+
+Pal::Result PalDevice::init_queue_and_cmd_buffer(queue_and_cmd_buffer_type type) {
+    // Choose queue and engine type corresponding to queue_and_cmd_buffer_type.
+    Pal::QueueType queue_type;
+    Pal::EngineType engine_type;
+    switch (type) {
+        case queue_and_cmd_buffer_type::Compute:
+            queue_type = Pal::QueueType::QueueTypeCompute;
+            engine_type = Pal::EngineType::EngineTypeCompute;
+            break;
+        case queue_and_cmd_buffer_type::Universal:
+            queue_type = Pal::QueueType::QueueTypeUniversal;
+            engine_type = Pal::EngineType::EngineTypeUniversal;
+            break;
+        default:
+            // Queue and cmd buffer type not implemented.
+            assert(false);
+            break;
+    }
+
+    Pal::QueueCreateInfo queue_create_info = {};
+    queue_create_info.queueType = queue_type;
+    queue_create_info.engineType = engine_type;
+
+    Pal::Result result  = Pal::Result::ErrorUnknown;
+
+    // Create the queue
+    const size_t queue_size = device_->GetQueueSize(queue_create_info, &result);
+    CHECK_PAL(result, "GetQueueSize()");
+
+    result = device_->CreateQueue(queue_create_info, malloc(queue_size), &queue_);
+    CHECK_PAL(result, "CreateQueue()");
+
+    // Create the command buffer.
+    Pal::CmdBufferCreateInfo cmd_buffer_create_info = {};
+    cmd_buffer_create_info.pCmdAllocator = cmd_allocator_;
+    cmd_buffer_create_info.queueType = queue_type;
+    cmd_buffer_create_info.engineType = engine_type;
+
+    const size_t cmdBufSize = device_->GetCmdBufferSize(cmd_buffer_create_info, &result);
+    CHECK_PAL(result, "GetCmdBufferSize()");
+
+    return device_->CreateCmdBuffer(cmd_buffer_create_info, malloc(cmdBufSize), &cmd_buffer_);
+}
+
+PalDevice::GpuVirtAddr_t PalDevice::allocate_gpu_memory(Pal::gpusize size_in_bytes, Pal::GpuHeap heap) {
+    Pal::IGpuMemory* memory;
+    Pal::Result result = allocate_memory(size_in_bytes, heap, &memory);
+    CHECK_PAL(result, "allocate_gpu_memory(GpuHeapInvisible)");
+    const auto gpu_virtual_addr = track_memory(memory);
+    return gpu_virtual_addr;
+}
+
+Pal::Result PalDevice::allocate_memory(
+    Pal::gpusize size_in_bytes, Pal::GpuHeap heap, Pal::IGpuMemory** gpu_memory_pp, Pal::gpusize alignment) {
+    Pal::GpuMemoryHeapProperties heap_properties[Pal::GpuHeapCount] = {};
+    Pal::Result result = device_->GetGpuMemoryHeapProperties(&heap_properties[0]);
+    CHECK_PAL(result, "GetGpuMemoryHeapProperties()");
+
+    Pal::GpuMemoryCreateInfo create_info = {};
+    create_info.alignment = alignment;
+    create_info.size = size_in_bytes;
+    create_info.flags.cpuInvisible = ((heap_properties[heap].flags.cpuVisible == 0) ? 1 : 0);
+    create_info.vaRange = Pal::VaRange::Default;
+    create_info.heapCount = 1;
+    create_info.priority = Pal::GpuMemPriority::Normal;
+    create_info.priorityOffset = Pal::GpuMemPriorityOffset::Offset0;
+    create_info.heaps[0] = heap;
+    create_info.mallPolicy = Pal::GpuMemMallPolicy::Always;
+
+    const size_t gpu_memory_size = device_->GetGpuMemorySize(create_info, &result);
+    CHECK_PAL(result, "GetGpuMemorySize()");
+
+    result = device_->CreateGpuMemory(create_info, malloc(gpu_memory_size), gpu_memory_pp);
+    CHECK_PAL(result, "CreateGpuMemory()");
+
+    Pal::GpuMemoryRef mem_ref = {};
+    mem_ref.pGpuMemory = *gpu_memory_pp;
+
+    // Make this allocation permanently resident. We might want to track  which allocations are actually being
+    // used and only make those resident but in AnyDSL usually the user takes care of releasing memory as soon
+    // as it's not used anymore.
+    return device_->AddGpuMemoryReferences(1, &mem_ref, nullptr, Pal::GpuMemoryRefCantTrim);
+}
+
+PalDevice::GpuVirtAddr_t PalDevice::allocate_shared_virtual_memory(Pal::gpusize sizeInBytes) {
+    Pal::SvmGpuMemoryCreateInfo create_info = {};
+    create_info.size = sizeInBytes;
+    create_info.alignment =
+        4096; // This seems to be the minimum alignment needed to avoid triggering asserts in PAL
+    create_info.mallPolicy = Pal::GpuMemMallPolicy::Always;
+    create_info.isUsedForKernel = false;
+    create_info.pReservedGpuVaOwner = nullptr;
+
+    Pal::Result result = Pal::Result::Success;
+    const size_t gpu_memory_size = device_->GetSvmGpuMemorySize(create_info, &result);
+    CHECK_PAL(result, "GetSvmGpuMemorySize()");
+
+    Pal::IGpuMemory* shared_virtual_memory;
+    result = device_->CreateSvmGpuMemory(create_info, malloc(gpu_memory_size), &shared_virtual_memory);
+    CHECK_PAL(result, "CreateSvmGpuMemory()");
+
+    const auto shared_virtual_addr = track_memory(shared_virtual_memory);
+    return shared_virtual_addr;
+}
+
+PalDevice::GpuVirtAddr_t PalDevice::track_memory(Pal::IGpuMemory* memory) {
+    const GpuVirtAddr_t gpu_address = memory->Desc().gpuVirtAddr;
+    assert(memory_objects_.find(gpu_address) == memory_objects_.end()
+           && "Virtual address is already in memory_objects map.");
+    memory_objects_[gpu_address] = memory;
+    return gpu_address;
+}
+
+void PalDevice::forget_memory(GpuVirtAddr_t gpu_address) {
+    assert(memory_objects_.find(gpu_address) != memory_objects_.end()
+           && "Virtual address is already in memory_objects map.");
+
+    memory_objects_.erase(gpu_address);
+}
+
+Pal::IGpuMemory* PalDevice::get_memory_object(const GpuVirtAddr_t gpu_address) const {
+    auto memory_object_it = memory_objects_.find(gpu_address);
+    if (memory_object_it == memory_objects_.end()) {
+        assert(false && "Key (virtual gpu memory address) not in memory_objects map.");
+        return nullptr;
+    }
+    return memory_object_it->second;
+}
+
+void PalDevice::release_gpu_memory(GpuVirtAddr_t virtual_address) {
+    if (virtual_address == nulladdr) {
+        assert(false && "release() provided with nullptr.");
+        return;
+    }
+    Pal::IGpuMemory* memory = get_memory_object(virtual_address);
+    if (memory == nullptr) {
+        return;
+    }
+
+    memory->Destroy();
+    free(memory);
+    forget_memory(virtual_address);
+}
+
+void PalDevice::copy_gpu_data(
+    const GpuVirtAddr_t source, GpuVirtAddr_t destination, const Pal::MemoryCopyRegion& copy_region) {
+    Pal::CmdBufferBuildInfo cmd_buffer_build_info = {};
+    cmd_buffer_build_info.flags.optimizeExclusiveSubmit = 1;
+    Pal::Result result = cmd_buffer_->Begin(cmd_buffer_build_info);
+    CHECK_PAL(result, "cmd_buffer->Begin()");
+
+    // Add copy command to cmd buffer.
+    const Pal::uint32 region_count = 1;
+
+    const auto& src_memory = *get_memory_object(source);
+    const auto& dst_memory = *get_memory_object(destination);
+    cmd_buffer_->CmdCopyMemory(src_memory, dst_memory, region_count, &copy_region);
+
+    result = cmd_buffer_->End();
+    CHECK_PAL(result, "cmd_buffer->End()");
+
+    // Submit cmd buffer to queue.
+    Pal::PerSubQueueSubmitInfo per_sub_queue_submit_info = {};
+    per_sub_queue_submit_info.cmdBufferCount = 1;
+    per_sub_queue_submit_info.ppCmdBuffers = &cmd_buffer_;
+    per_sub_queue_submit_info.pCmdBufInfoList = nullptr;
+
+    Pal::SubmitInfo submit_info = {};
+    submit_info.pPerSubQueueInfo = &per_sub_queue_submit_info;
+    submit_info.perSubQueueInfoCount = 1;
+
+    result = queue_->Submit(submit_info);
+    CHECK_PAL(result, "queue->Submit()");
+
+    // Wait for queue to complete commands.
+    // TODO: Do we want this WaitIdle here?
+    result = queue_->WaitIdle();
+    CHECK_PAL(result, "queue->WaitIdle()");
+}
+
+void PalDevice::dispatch(const Pal::CmdBufferBuildInfo& cmd_buffer_build_info,
+    const Pal::PipelineBindParams& pipeline_bind_params, const Pal::BarrierInfo& barrier_info,
+    const LaunchParams& launch_params) {
+    // Make sure we can cast to uint16_t
+    assert(launch_params.block[0] <= 65535);
+    assert(launch_params.block[1] <= 65535);
+    assert(launch_params.block[2] <= 65535);
+
+    const uint16_t block_size_x = (uint16_t)launch_params.block[0];
+    const uint16_t block_size_y = (uint16_t)launch_params.block[1];
+    const uint16_t block_size_z = (uint16_t)launch_params.block[2];
+    // Grid size is provided in threads (not in thread groups, as pal expects).
+    const uint32_t grid_size_x = launch_params.grid[0];
+    const uint32_t grid_size_y = launch_params.grid[1];
+    const uint32_t grid_size_z = launch_params.grid[2];
+
+    const Pal::DispatchDims dispatch_dimensions{
+        .x = std::max(1u, ((grid_size_x + block_size_x - 1) / block_size_x)),
+        .y = std::max(1u, ((grid_size_y + block_size_y - 1) / block_size_y)),
+        .z = std::max(1u, ((grid_size_z + block_size_z - 1) / block_size_z)),
+    };
+
+    struct PalUserData {
+        Pal::uint32 buffer_vaddr[2];
+    } pal_user_data = {};
+
+    const bool are_params_present = launch_params.num_args > 0;
+    if (are_params_present) {
+        GpuVirtAddr_t kernargs_buffer =
+            build_kernargs_buffer(launch_params.args, launch_params.num_args, launch_params.kernel_name);
+        assert(kernargs_buffer && "Kernargs buffer could not be built for launch param arguments.");
+
+        std::memcpy(&pal_user_data.buffer_vaddr, &kernargs_buffer, sizeof(uint64_t));
+    }
+
+    Pal::Result result = cmd_buffer_->Begin(cmd_buffer_build_info);
+    CHECK_PAL(result, "cmdBuffer->Begin()");
+
+    // Omit first two uint32s (hold parameter buffer address) in the struct if there are no parameters.
+    cmd_buffer_->CmdSetUserData(Pal::PipelineBindPoint::Compute, 0, are_params_present ? 2 : 0,
+        reinterpret_cast<Pal::uint32*>(&pal_user_data));
+
+    cmd_buffer_->CmdBindPipeline(pipeline_bind_params);
+
+    cmd_buffer_->CmdDispatch(dispatch_dimensions);
+    cmd_buffer_->CmdBarrier(barrier_info);
+    result = cmd_buffer_->End();
+    CHECK_PAL(result, "cmdBuffer->End()");
+
+    Pal::PerSubQueueSubmitInfo per_sub_queue_submit_info = {};
+    per_sub_queue_submit_info.cmdBufferCount = 1;
+    per_sub_queue_submit_info.ppCmdBuffers = &cmd_buffer_;
+    per_sub_queue_submit_info.pCmdBufInfoList = nullptr;
+
+    Pal::SubmitInfo submit_info = {};
+    submit_info.pPerSubQueueInfo = &per_sub_queue_submit_info;
+    submit_info.perSubQueueInfoCount = 1;
+
+    result = queue_->Submit(submit_info);
+    CHECK_PAL(result, "queue->Submit()");
+}
+
+PalDevice::GpuVirtAddr_t PalDevice::write_data_to_gpu(
+    Pal::gpusize byte_size, std::function<void(void*)> write_callback) {
+    PalDevice::GpuVirtAddr_t gpu_only_buffer =
+        allocate_gpu_memory(byte_size, pal_utils::find_gpu_local_heap(device_, byte_size));
+
+    PalDevice::GpuVirtAddr_t intermediate_mem = allocate_gpu_memory(byte_size, Pal::GpuHeap::GpuHeapLocal);
+    {
+        Pal::IGpuMemory* intermediate_mem_obj = get_memory_object(intermediate_mem);
+        void* mapped_intermediate = nullptr;
+        Pal::Result result = intermediate_mem_obj->Map(&mapped_intermediate);
+        CHECK_PAL(result, "intermediate_mem_obj->Map()");
+
+        write_callback(mapped_intermediate);
+
+        result = intermediate_mem_obj->Unmap();
+        CHECK_PAL(result, "intermediate_mem_obj->Unmap()");
+    }
+    copy_gpu_data(intermediate_mem, gpu_only_buffer, {.srcOffset = 0, .dstOffset = 0, .copySize = byte_size});
+    release_gpu_memory(intermediate_mem);
+
+    return gpu_only_buffer;
+}
+
+uint32_t round_up(uint32_t val, uint32_t step_size) {
+    return (val + step_size - 1) / step_size * step_size;
+}
+
+uint32_t PalDevice::calculate_launch_params_size(const ParamsArgs& params_args, uint32_t num_args) {
+    uint32_t total_size = 0;
+    for (uint32_t i = 0; i < num_args; i++) {
+        total_size = round_up(total_size, params_args.aligns[i]) + params_args.alloc_sizes[i];
+    }
+    return total_size;
+};
+
+size_t PalDevice::write_launch_params(const ParamsArgs& params_args, uint32_t num_args, void* memory, size_t memory_size) {
+    const uint8_t* const initial_memory_ptr = reinterpret_cast<uint8_t*>(memory);
+    for (uint32_t i = 0; i < num_args; i++) {
+        // align base address for next kernel argument
+        if (!std::align(
+                params_args.aligns[i], params_args.alloc_sizes[i], memory, memory_size)) {
+            error("Incorrect kernel argument alignment detected.");
+        }
+        std::memcpy(memory, params_args.data[i], params_args.sizes[i]);
+        memory = reinterpret_cast<uint8_t*>(memory) + params_args.alloc_sizes[i];
+    }
+    // Return the number of bytes occupied by launch_paramas.
+    return reinterpret_cast<uint8_t*>(memory) - initial_memory_ptr;
+}
+
+PalDevice::GpuVirtAddr_t PalDevice::build_kernargs_buffer(
+    const ParamsArgs& params_args, int num_args, const char* kernel_name) {
+    if (num_args == 0)
+        return nulladdr;
+
+    uint32_t kernarg_segment_size = calculate_launch_params_size(params_args, num_args);
+
+    size_t used_memory;
+    GpuVirtAddr_t kernargs_buffer = write_data_to_gpu(kernarg_segment_size, [&](void* dest_mem) {
+        used_memory = write_launch_params(params_args, num_args, dest_mem, kernarg_segment_size);
+    });
+
+    if (used_memory != kernarg_segment_size) {
+        error("PAL kernarg segment size for kernel '%' differs from argument size: % vs. %", kernel_name,
+            kernarg_segment_size, used_memory);
+    }
+
+    return kernargs_buffer;
+}

--- a/src/pal/pal_device.cpp
+++ b/src/pal/pal_device.cpp
@@ -1,5 +1,3 @@
-// Copyright (c) 2023 Advanced Micro Devices, Inc. All rights reserved.
-
 #include "pal_device.h"
 #include "pal_utils.h"
 

--- a/src/pal/pal_device.cpp
+++ b/src/pal/pal_device.cpp
@@ -7,12 +7,6 @@
 
 constexpr const PalDevice::GpuVirtAddr_t nulladdr = 0;
 
-inline void check_pal_error(Pal::Result err, const char* name, const char* file, const int line) {
-    if (err != Pal::Result::Success) {
-        error("PAL API function % [file %, line %]: %", name, file, line, static_cast<int32_t>(err));
-    }
-}
-
 void pal_destroy(Pal::IDestroyable* object) {
     assert(object != nullptr);
     object->Destroy();
@@ -276,9 +270,8 @@ Pal::Result PalDevice::allocate_memory(
     Pal::GpuMemoryRef mem_ref = {};
     mem_ref.pGpuMemory = *gpu_memory_pp;
 
-    // Make this allocation permanently resident. We might want to track  which allocations are actually being
-    // used and only make those resident but in AnyDSL usually the user takes care of releasing memory as soon
-    // as it's not used anymore.
+    // Make this allocation permanently resident. In AnyDSL usually the user takes care of
+    // releasing memory as soon as it's not used anymore.
     return device_->AddGpuMemoryReferences(1, &mem_ref, nullptr, Pal::GpuMemoryRefCantTrim);
 }
 
@@ -313,7 +306,7 @@ PalDevice::GpuVirtAddr_t PalDevice::track_memory(Pal::IGpuMemory* memory) {
 
 void PalDevice::forget_memory(GpuVirtAddr_t gpu_address) {
     assert(memory_objects_.find(gpu_address) != memory_objects_.end()
-           && "Virtual address is already in memory_objects map.");
+           && "Virtual address is not in memory_objects map.");
 
     memory_objects_.erase(gpu_address);
 }

--- a/src/pal/pal_device.h
+++ b/src/pal/pal_device.h
@@ -1,5 +1,3 @@
-// Copyright (c) 2023 Advanced Micro Devices, Inc. All rights reserved.
-
 #ifndef PAL_DEVICE_DATA_H
 #define PAL_DEVICE_DATA_H
 

--- a/src/pal/pal_device.h
+++ b/src/pal/pal_device.h
@@ -1,0 +1,139 @@
+// Copyright (c) 2023 Advanced Micro Devices, Inc. All rights reserved.
+
+#ifndef PAL_DEVICE_DATA_H
+#define PAL_DEVICE_DATA_H
+
+#include "../runtime.h"
+#include "pal_utils.h"
+
+#include <atomic>
+#include <functional>
+#include <string>
+#include <unordered_map>
+
+#include <pal.h>
+#include <palLib.h>
+#include <palPipeline.h>
+#include <palPlatform.h>
+#include <palQueue.h>
+
+class PALPlatform;
+
+class PalDevice {
+public:
+    typedef Pal::gpusize GpuVirtAddr_t;
+    typedef std::unordered_map<std::string, Pal::IPipeline*> KernelMap;
+
+    enum class queue_and_cmd_buffer_type { Compute, Universal };
+
+    PalDevice(){};
+    PalDevice(Pal::IDevice* base_device);
+    PalDevice(const PalDevice&) = delete;
+    PalDevice(PalDevice&& other)
+        : device_(other.device_)
+        , cmd_allocator_(other.cmd_allocator_)
+        , queue_(other.queue_)
+        , cmd_buffer_(other.cmd_buffer_)
+        , programs_(std::move(other.programs_))
+        , kernels_(std::move(other.kernels_))
+        , memory_objects_(std::move(other.memory_objects_))
+        , gfx_level(other.gfx_level)
+        , isa(std::move(other.isa))
+        , name(std::move(other.name)) {}
+
+    ~PalDevice();
+
+    void lock() {
+        while (locked_.test_and_set(std::memory_order_acquire))
+            ;
+    }
+
+    void unlock() { locked_.clear(std::memory_order_release); }
+
+    Pal::IPipeline* create_pipeline(const void* elf_data, size_t elf_data_size);
+
+    // Allocates memory of the requested size on the requested gpu heap (controls visibility).
+    // Returns the virtual gpu address of the allocated memory.
+    GpuVirtAddr_t allocate_gpu_memory(Pal::gpusize size_in_bytes, Pal::GpuHeap heap);
+
+    GpuVirtAddr_t allocate_shared_virtual_memory(Pal::gpusize sizeInBytes);
+
+    void release_gpu_memory(GpuVirtAddr_t virtual_address);
+    void release_gpu_memory(void* virtual_address) {
+        release_gpu_memory(reinterpret_cast<PalDevice::GpuVirtAddr_t>(virtual_address));
+    }
+
+    void copy_gpu_data(
+        const GpuVirtAddr_t source, GpuVirtAddr_t destination, const Pal::MemoryCopyRegion& copy_region);
+    void copy_gpu_data(const void* source, void* destination, const Pal::MemoryCopyRegion& copy_region) {
+        copy_gpu_data(reinterpret_cast<PalDevice::GpuVirtAddr_t>(source),
+            reinterpret_cast<PalDevice::GpuVirtAddr_t>(destination), copy_region);
+    }
+
+    void dispatch(const Pal::CmdBufferBuildInfo& cmd_buffer_build_info,
+        const Pal::PipelineBindParams& pipeline_bind_params, const Pal::BarrierInfo& barrier_info,
+        const LaunchParams& launch_params);
+
+private:
+    friend PALPlatform;
+
+    Pal::Result init();
+
+    // Creates a PAL queue object and corresponding command buffer object.
+    // Since AnyDSL only supports Compute dispatches, any kind of queue,
+    // except copy-only-queues, can be used.
+    Pal::Result init_queue_and_cmd_buffer(queue_and_cmd_buffer_type type);
+
+    // Creates a PAL command allocator which is needed to allocate memory for all
+    // command buffer objects.
+    Pal::Result init_cmd_allocator();
+
+    Pal::Result allocate_memory(Pal::gpusize size_in_bytes, Pal::GpuHeap heap,
+        Pal::IGpuMemory** gpu_memory_pp, Pal::gpusize alignment = 256 * 1024);
+
+    // Returns the key to the new map entry. This key is the virtual gpu memory address.
+    GpuVirtAddr_t track_memory(Pal::IGpuMemory* memory);
+    void forget_memory(GpuVirtAddr_t gpu_address);
+    // Returns nullptr if key is not present in memory_objects map.
+    Pal::IGpuMemory* get_memory_object(const GpuVirtAddr_t gpu_address) const;
+    Pal::IGpuMemory* get_memory_object(const void* gpu_address) const {
+        return get_memory_object(reinterpret_cast<PalDevice::GpuVirtAddr_t>(gpu_address));
+    }
+
+    // Build a buffer holding the kernel arguments and upload to the GPU.
+    // Returns the address of the buffer on the gpu.
+    GpuVirtAddr_t build_kernargs_buffer(const ParamsArgs& params_args, int num_args, const char* kernel_name);
+
+    // Helper function that allocates a gpu-only buffer of the given size and uploads the data written by the
+    // write_callback
+    PalDevice::GpuVirtAddr_t write_data_to_gpu(
+        Pal::gpusize byte_size, std::function<void(void*)> write_callback);
+
+    uint32_t calculate_launch_params_size(const ParamsArgs& params_args, uint32_t num_args);
+    // Write kernel arguments to memory. Returns the number of bytes occupied by the passed in kernel arguments.
+    size_t write_launch_params(const ParamsArgs& params_args, uint32_t num_args, void* memory, size_t memory_size);
+
+private:
+    Pal::IDevice* device_ = nullptr;
+    Pal::ICmdAllocator* cmd_allocator_ = nullptr;
+    Pal::IQueue* queue_ = nullptr;
+    Pal::ICmdBuffer* cmd_buffer_ = nullptr;
+
+    std::atomic_flag locked_ = ATOMIC_FLAG_INIT;
+
+    std::unordered_map<std::string, Pal::IPipeline*> programs_;
+    std::unordered_map<uint64_t, KernelMap> kernels_;
+
+    // Map virtual addresses on the GPU to the PAL objects representing the memory.
+    // This is needed because AnyDSL assumes it deals with gpu-legal addresses in its API.
+    // However, to interact with PAL we need to have the wrapper objects at hand.
+    // The IGpuMemory objects should not be used outside of this class.
+    std::unordered_map<GpuVirtAddr_t, Pal::IGpuMemory*> memory_objects_;
+
+public:
+    Pal::GfxIpLevel gfx_level;
+    std::string isa;
+    std::string name;
+};
+
+#endif

--- a/src/pal/pal_device.h
+++ b/src/pal/pal_device.h
@@ -24,7 +24,7 @@ public:
     typedef Pal::gpusize GpuVirtAddr_t;
     typedef std::unordered_map<std::string, Pal::IPipeline*> KernelMap;
 
-    enum class queue_and_cmd_buffer_type { Compute, Universal };
+    enum class queue_and_cmd_buffer_type { Compute, Universal, Dma };
 
     PalDevice(){};
     PalDevice(Pal::IDevice* base_device, Runtime* runtime);
@@ -82,10 +82,8 @@ private:
 
     Pal::Result init();
 
-    // Creates a PAL queue object and corresponding command buffer object.
-    // Since AnyDSL only supports Compute dispatches, any kind of queue,
-    // except copy-only-queues, can be used.
-    Pal::Result init_queue_and_cmd_buffer(queue_and_cmd_buffer_type type);
+    // Creates a PAL queue object and corresponding command buffer object into the given pointers.
+    Pal::Result init_queue_and_cmd_buffer(queue_and_cmd_buffer_type type, Pal::IQueue*& queue, Pal::ICmdBuffer*& cmd_buffer);
 
     // Creates a PAL command allocator which is needed to allocate memory for all
     // command buffer objects.
@@ -123,6 +121,9 @@ private:
     Pal::ICmdAllocator* cmd_allocator_ = nullptr;
     Pal::IQueue* queue_ = nullptr;
     Pal::ICmdBuffer* cmd_buffer_ = nullptr;
+
+    Pal::IQueue* dma_queue_ = nullptr;
+    Pal::ICmdBuffer* dma_cmd_buffer_ = nullptr;
 
     struct ProfilingTimestamps {
         uint64_t start;

--- a/src/pal/pal_device.h
+++ b/src/pal/pal_device.h
@@ -77,6 +77,8 @@ public:
         const Pal::PipelineBindParams& pipeline_bind_params, const Pal::BarrierInfo& barrier_info,
         const LaunchParams& launch_params);
 
+    void WaitIdle();
+
 private:
     friend PALPlatform;
 

--- a/src/pal/pal_device.h
+++ b/src/pal/pal_device.h
@@ -27,13 +27,16 @@ public:
     enum class queue_and_cmd_buffer_type { Compute, Universal };
 
     PalDevice(){};
-    PalDevice(Pal::IDevice* base_device);
+    PalDevice(Pal::IDevice* base_device, Runtime* runtime);
     PalDevice(const PalDevice&) = delete;
     PalDevice(PalDevice&& other)
-        : device_(other.device_)
+        : runtime_(other.runtime_)
+        , device_(other.device_)
         , cmd_allocator_(other.cmd_allocator_)
         , queue_(other.queue_)
         , cmd_buffer_(other.cmd_buffer_)
+        , profiling_timestamps_(other.profiling_timestamps_)
+        , timestamps_frequency_(other.timestamps_frequency_)
         , programs_(std::move(other.programs_))
         , kernels_(std::move(other.kernels_))
         , memory_objects_(std::move(other.memory_objects_))
@@ -114,10 +117,19 @@ private:
     size_t write_launch_params(const ParamsArgs& params_args, uint32_t num_args, void* memory, size_t memory_size);
 
 private:
+    Runtime* runtime_ = nullptr;
+
     Pal::IDevice* device_ = nullptr;
     Pal::ICmdAllocator* cmd_allocator_ = nullptr;
     Pal::IQueue* queue_ = nullptr;
     Pal::ICmdBuffer* cmd_buffer_ = nullptr;
+
+    struct ProfilingTimestamps {
+        uint64_t start;
+        uint64_t end;
+    };
+    Pal::IGpuMemory* profiling_timestamps_ = nullptr;
+    uint64_t timestamps_frequency_ = 0;
 
     std::atomic_flag locked_ = ATOMIC_FLAG_INIT;
 

--- a/src/pal/pal_fix_calling_convention_pass.cpp
+++ b/src/pal/pal_fix_calling_convention_pass.cpp
@@ -1,0 +1,45 @@
+// Copyright (c) 2023 Advanced Micro Devices, Inc. All rights reserved.
+
+#include "pal_fix_calling_convention_pass.h"
+#include "pal_utils.h"
+
+#include <unordered_set>
+
+#include <llvm/IR/CallingConv.h>
+#include <llvm/IR/Function.h>
+#include <llvm/IR/IRBuilder.h>
+
+using namespace llvm;
+
+void fix_calling_conv(Module* m, Function* f, std::unordered_set<Function*>& traversed_functions) {
+    if (traversed_functions.find(f) != traversed_functions.end()) {
+        // already visited this function -> prevent recursive loop
+        return;
+    }
+
+    traversed_functions.insert(f);
+    f->addFnAttr(llvm::Attribute::AlwaysInline);
+
+    // Find and inspect all function calls inside of this function
+    for (auto& bb : *f) {
+        for (auto& instruction : bb) {
+            if (CallInst* call_inst = dyn_cast<CallInst>(&instruction)) {
+                if (call_inst->getCallingConv() != CallingConv::AMDGPU_Gfx) {
+                    call_inst->setCallingConv(CallingConv::AMDGPU_Gfx);
+                }
+
+                if (Function* called_function = call_inst->getCalledFunction()) {
+                    fix_calling_conv(m, called_function, traversed_functions);
+                }
+            }
+        }
+    }
+}
+
+PreservedAnalyses PalPlatformFixCallingConventionPass::run(Module& M, ModuleAnalysisManager&) {
+    std::unordered_set<Function*> traversed_functions = {};
+    for (Function& entrypoint_fn : M) {
+        fix_calling_conv(&M, &entrypoint_fn, traversed_functions);
+    }
+    return PreservedAnalyses::all();
+}

--- a/src/pal/pal_fix_calling_convention_pass.cpp
+++ b/src/pal/pal_fix_calling_convention_pass.cpp
@@ -1,5 +1,3 @@
-// Copyright (c) 2023 Advanced Micro Devices, Inc. All rights reserved.
-
 #include "pal_fix_calling_convention_pass.h"
 #include "pal_utils.h"
 

--- a/src/pal/pal_fix_calling_convention_pass.h
+++ b/src/pal/pal_fix_calling_convention_pass.h
@@ -1,0 +1,14 @@
+// Copyright (c) 2023 Advanced Micro Devices, Inc. All rights reserved.
+
+#ifndef PAL_PLATFORM_FIX_CALLING_CONVENTION_H
+#define PAL_PLATFORM_FIX_CALLING_CONVENTION_H
+
+#include <llvm/IR/PassManager.h>
+
+/// This pass sets the calling convention to AMDGPU_Gfx for all calls in the given module and sets the AlwaysInline
+/// Attribute on every called function in the module to avoid the LLVM AMDGPU backend throwing errors.
+struct PalPlatformFixCallingConventionPass : llvm::PassInfoMixin<PalPlatformFixCallingConventionPass> {
+    llvm::PreservedAnalyses run(llvm::Module& M, llvm::ModuleAnalysisManager&);
+};
+
+#endif // PAL_PLATFORM_FIX_CALLING_CONVENTION_H

--- a/src/pal/pal_fix_calling_convention_pass.h
+++ b/src/pal/pal_fix_calling_convention_pass.h
@@ -1,5 +1,3 @@
-// Copyright (c) 2023 Advanced Micro Devices, Inc. All rights reserved.
-
 #ifndef PAL_PLATFORM_FIX_CALLING_CONVENTION_H
 #define PAL_PLATFORM_FIX_CALLING_CONVENTION_H
 

--- a/src/pal/pal_insert_halt_pass.cpp
+++ b/src/pal/pal_insert_halt_pass.cpp
@@ -1,0 +1,30 @@
+// Copyright (c) 2023 Advanced Micro Devices, Inc. All rights reserved.
+
+#include "pal_insert_halt_pass.h"
+#include "pal_utils.h"
+
+#include <llvm/IR/CallingConv.h>
+#include <llvm/IR/Function.h>
+#include <llvm/IR/IRBuilder.h>
+#include <llvm/IR/InlineAsm.h>
+
+#include <cstdlib>
+
+using namespace llvm;
+
+PreservedAnalyses PalPlatformInsertHaltPass::run(Function& F, FunctionAnalysisManager&) {
+    char* halt_immediately = std::getenv("HALT_IMMEDIATELY");
+    if (F.getName() != pal_utils::ComputeShaderMainFnName || !halt_immediately
+        || strcmp(halt_immediately, "ON") != 0) {
+        return PreservedAnalyses::all();
+    }
+    assert(F.getCallingConv() == CallingConv::AMDGPU_CS);
+    LLVMContext& Ctx = F.getParent()->getContext();
+    BasicBlock& EntryBlock = *F.begin();
+    IRBuilder<> Builder(&(*EntryBlock.getFirstInsertionPt()));
+    ArrayRef<Value*> inline_asm_args;
+    InlineAsm* inline_assembly = InlineAsm::get(
+        FunctionType::get(Type::getVoidTy(Ctx), false), "s_sethalt 1", "", true, false, InlineAsm::AD_ATT);
+    Builder.CreateCall(inline_assembly, inline_asm_args);
+    return PreservedAnalyses::none();
+}

--- a/src/pal/pal_insert_halt_pass.cpp
+++ b/src/pal/pal_insert_halt_pass.cpp
@@ -1,5 +1,3 @@
-// Copyright (c) 2023 Advanced Micro Devices, Inc. All rights reserved.
-
 #include "pal_insert_halt_pass.h"
 #include "pal_utils.h"
 

--- a/src/pal/pal_insert_halt_pass.h
+++ b/src/pal/pal_insert_halt_pass.h
@@ -1,5 +1,3 @@
-// Copyright (c) 2023 Advanced Micro Devices, Inc. All rights reserved.
-
 #ifndef PAL_PLATFORM_INSERT_HALT_PASS_H
 #define PAL_PLATFORM_INSERT_HALT_PASS_H
 

--- a/src/pal/pal_insert_halt_pass.h
+++ b/src/pal/pal_insert_halt_pass.h
@@ -1,0 +1,15 @@
+// Copyright (c) 2023 Advanced Micro Devices, Inc. All rights reserved.
+
+#ifndef PAL_PLATFORM_INSERT_HALT_PASS_H
+#define PAL_PLATFORM_INSERT_HALT_PASS_H
+
+#include <llvm/IR/PassManager.h>
+#include <llvm/Pass.h>
+
+/// Pass that inserts RDNA specific assembly to halt a shader as soon as it starts if the environment variable
+/// "HALT_IMMEDIATELY" is set to the value "ON"
+struct PalPlatformInsertHaltPass : llvm::PassInfoMixin<PalPlatformInsertHaltPass> {
+    llvm::PreservedAnalyses run(llvm::Function& F, llvm::FunctionAnalysisManager& FAM);
+};
+
+#endif // PAL_PLATFORM_INSERT_HALT_PASS_H

--- a/src/pal/pal_lower_builtins_pass.cpp
+++ b/src/pal/pal_lower_builtins_pass.cpp
@@ -1,5 +1,3 @@
-// Copyright (c) 2023 Advanced Micro Devices, Inc. All rights reserved.
-
 #include "pal_lower_builtins_pass.h"
 #include "pal_utils.h"
 

--- a/src/pal/pal_lower_builtins_pass.cpp
+++ b/src/pal/pal_lower_builtins_pass.cpp
@@ -1,0 +1,324 @@
+// Copyright (c) 2023 Advanced Micro Devices, Inc. All rights reserved.
+
+#include "pal_lower_builtins_pass.h"
+#include "pal_utils.h"
+
+#include <array>
+#include <unordered_map>
+#include <unordered_set>
+#include <vector>
+
+#include <llvm/IR/CallingConv.h>
+#include <llvm/IR/Function.h>
+#include <llvm/IR/GlobalValue.h>
+#include <llvm/IR/IRBuilder.h>
+#include <llvm/IR/InlineAsm.h>
+#include <llvm/IR/MDBuilder.h>
+#include <llvm/Target/TargetMachine.h>
+
+using namespace llvm;
+
+namespace {
+// anonymous namespace to avoid name clashes
+
+enum Builtins : int8_t {
+    workitem_id_x = 0,
+    workitem_id_y,
+    workitem_id_z,
+    workgroup_id_x,
+    workgroup_id_y,
+    workgroup_id_z,
+    nblk_x,
+    nblk_y,
+    nblk_z,
+    // Dynamic builtins (i.e., inlined code based on supplied metadata)
+    workgroup_size_x,
+    workgroup_size_y,
+    workgroup_size_z,
+    count
+};
+
+constexpr const char* BuiltinNames[] = {
+    "anydsl.amdpal.workitem.id.x",
+    "anydsl.amdpal.workitem.id.y",
+    "anydsl.amdpal.workitem.id.z",
+    "anydsl.amdpal.workgroup.id.x",
+    "anydsl.amdpal.workgroup.id.y",
+    "anydsl.amdpal.workgroup.id.z",
+    "anydsl.amdpal.nblk.x",
+    "anydsl.amdpal.nblk.y",
+    "anydsl.amdpal.nblk.z",
+    // Dynamic builtins (i.e., inlined code based on supplied metadata)
+    "anydsl.amdpal.workgroup.size.x",
+    "anydsl.amdpal.workgroup.size.y",
+    "anydsl.amdpal.workgroup.size.z",
+};
+
+struct BuiltinAssemblyInfo {
+    const char* asmString;
+    const char* asmConstraints;
+};
+
+// PAL SGPR layout:
+// s0-1:   PAL reserved data -> set up by PAL because of pipeline register configuration in PALPlatform
+// s2-3:   pointer to pal kernel args (for compute shader)
+//         -> set up by AnyDSL PALPlatform
+// s4-5:   pointer to NumWorkGroups struct (i.e., nblk)
+// s6-12:  reserved for future use
+// s13-15: work group id x, y, and z -> set up by AnyDSL PALPlatform by supplying pgm_rsrc2
+//         ENABLE_SGPR_WORKGROUP_ID_<x/y/z> to PAL pipeline setup
+
+const BuiltinAssemblyInfo BuiltinAssemblyInfos[]{
+    // workitem_id_x
+    {
+        .asmString = "; local thread id x is in v0",
+        .asmConstraints = "={v0}",
+    },
+    // workitem_id_y
+    {
+        .asmString = "; local thread id y is in v1",
+        .asmConstraints = "={v1}",
+    },
+    // workitem_id_z
+    {
+        .asmString = "; local thread id z is in v2",
+        .asmConstraints = "={v2}",
+    },
+    // workgroup_id_x
+    {
+        .asmString = "; workgroup id x is in s13",
+        .asmConstraints = "={s13}",
+    },
+    // workgroup_id_y
+    {
+        .asmString = "; workgroup id y is in s14",
+        .asmConstraints = "={s14}",
+    },
+    // workgroup_id_z
+    {
+        .asmString = "; workgroup id z is in s15",
+        .asmConstraints = "={s15}",
+    },
+    // nblk_x
+    {
+        .asmString = "s_load_dword $0, s[4:5], 0x00",
+        .asmConstraints = "=s",
+    },
+    // nblk_y
+    {
+        .asmString = "s_load_dword $0, s[4:5], 0x04",
+        .asmConstraints = "=s",
+    },
+    // nblk_z
+    {
+        .asmString = "s_load_dword $0, s[4:5], 0x08",
+        .asmConstraints = "=s",
+    },
+};
+
+typedef std::array<std::vector<CallInst*>, static_cast<size_t>(Builtins::count)> BuiltinsCallInstMap;
+
+Builtins GetBuiltinID(Function* f) {
+    const StringRef f_name = f->getName();
+    for (int8_t i = 0; i < Builtins::count; ++i) {
+        if (f_name == BuiltinNames[i]) {
+            return Builtins(i);
+        }
+    }
+    return Builtins::count;
+}
+
+const BuiltinAssemblyInfo& GetAssemblyInfo(Builtins builtinID) {
+    return BuiltinAssemblyInfos[static_cast<int>(builtinID)];
+}
+
+bool IsBuiltin(Function* f) { return GetBuiltinID(f) < Builtins::count; }
+
+void find_builtins_calls(Module* m, Function* f, BuiltinsCallInstMap& builtins_call_instances,
+    std::unordered_set<Function*>& traversed_functions) {
+    if (traversed_functions.find(f) != traversed_functions.end()) {
+        // already visited this function -> prevent recursive loop
+        return;
+    }
+
+    traversed_functions.insert(f);
+
+    // Find and inspect all function calls inside of this function
+    for (auto& bb : *f) {
+        for (auto& instruction : bb) {
+            CallInst* callInst = dyn_cast<CallInst>(&instruction);
+            if (!callInst) {
+                continue;
+            }
+            
+            Function* calledFunction = callInst->getCalledFunction();
+            if (!calledFunction) {
+                continue;
+            }
+
+            if (IsBuiltin(calledFunction)) {
+                // If the call we found is calling a builtin, record the builtins usage
+                Builtins builtinID = GetBuiltinID(calledFunction);
+                builtins_call_instances[static_cast<int>(builtinID)].push_back(callInst);
+            } else if (calledFunction->getParent() == m) {
+                // If the called function is within this module, recursively search it for
+                // builtins used
+                find_builtins_calls(m, calledFunction, builtins_call_instances, traversed_functions);
+            }
+        }
+    }
+}
+
+Function* find_entrypoint(Module& M) {
+    for (Function& F : M) {
+        const auto name = F.getName();
+        if (name.equals(pal_utils::ComputeShaderMainFnName))
+            return &F;
+    }
+
+    return nullptr;
+}
+
+// Function taken from llvm-project/llvm/lib/Target/AMDGPU/AMDGPULowerKernelArguments.cpp
+BasicBlock::iterator getInsertPt(BasicBlock& BB) {
+    BasicBlock::iterator InsPt = BB.getFirstInsertionPt();
+    for (BasicBlock::iterator E = BB.end(); InsPt != E; ++InsPt) {
+        AllocaInst* AI = dyn_cast<AllocaInst>(&*InsPt);
+
+        // If this is a dynamic alloca, the value may depend on the loaded kernargs,
+        // so loads will need to be inserted before it.
+        if (!AI || !AI->isStaticAlloca())
+            break;
+    }
+
+    return InsPt;
+}
+
+CallInst* insert_asm(
+    IRBuilder<>& Builder, LLVMContext& Ctx, const char* asm_string, const char* asm_constraint) {
+    ArrayRef<Value*> inline_asm_args;
+    InlineAsm* inline_assembly = InlineAsm::get(FunctionType::get(Type::getInt32Ty(Ctx), false), asm_string,
+        asm_constraint, true, false, InlineAsm::AD_ATT);
+    return Builder.CreateCall(inline_assembly, inline_asm_args);
+}
+
+// Inserts assembly code to split the local thread id from v0 into v0(x), v1(y) and v2(z).
+// This is only applicable for GPUs >= gfx 11.
+void insert_asm_to_split_local_thread_id(IRBuilder<>& Builder, LLVMContext& Ctx,
+    const BuiltinsCallInstMap& builtins_call_instances, Pal::GfxIpLevel gfx_level) {
+    assert(gfx_level >= Pal::GfxIpLevel::GfxIp11_0);
+    // Write local thread id z into v2.
+    if (!builtins_call_instances[Builtins::workitem_id_z].empty()) {
+        insert_asm(Builder, Ctx,
+            "; def v2 local thread id z is in v0[29:20] (v0[31:30] set to 0 by hardware)\n\t"
+            "V_LSHRREV_B32 v2 20 v0",
+            "={v2}");
+    }
+    // Write local thread id y into v1.
+    if (!builtins_call_instances[Builtins::workitem_id_y].empty()) {
+        insert_asm(Builder, Ctx,
+            "; def v1 local thread id y is in v0[19:10]\n\t"
+            "V_LSHRREV_B32 v1 10 v0\n\t"
+            "V_AND_B32 v1 v1 0x3FF",
+            "={v1}");
+    }
+    // Write local thread id x into v0 last to make sure v0 is not overwritten yet.
+    if (!builtins_call_instances[Builtins::workitem_id_x].empty()) {
+        insert_asm(Builder, Ctx,
+            "; def v0 local thread id x is in v0[9:0]\n\t"
+            "V_AND_B32 v0 v0 0x3FF",
+            "={v0}");
+    }
+}
+
+} // namespace
+
+PreservedAnalyses PalPlatformLowerBuiltinsPass::run(Module& M, ModuleAnalysisManager&) {
+    Function* entrypoint_fn = find_entrypoint(M);
+    assert(entrypoint_fn);
+
+    /*
+    Find all calls to builtins and unique them
+    -> i.e. every builtin is only called exactly once right at the beginning of the shader.
+
+    for each instruction in entrypoint:
+        if call to builtin:
+            record builtin (unique set of used_builtins + all separate calls to them!)
+        elif call to another function inside this module:
+            recursively find all calls of used built_ins
+        else: don't care
+
+    for each used_builtin:
+        Value* real_builtin = insert inline_asm at beginning of entrypoint
+        for each call instance of the builtin:
+            replace all uses of call instance with real_builtin
+            remove old call instance
+    */
+
+    BuiltinsCallInstMap builtins_call_instances;
+    std::unordered_set<Function*> traversed_functions = {};
+    find_builtins_calls(&M, entrypoint_fn, builtins_call_instances, traversed_functions);
+
+    LLVMContext& Ctx = M.getContext();
+    BasicBlock& EntryBlock = *entrypoint_fn->begin();
+    IRBuilder<> Builder(&*getInsertPt(EntryBlock));
+
+    if (gfx_level_ >= Pal::GfxIpLevel::GfxIp11_0) {
+        insert_asm_to_split_local_thread_id(Builder, Ctx, builtins_call_instances, gfx_level_);
+    }
+
+    int builtins_count = static_cast<int>(Builtins::count);
+    for (int i = 0; i < builtins_count; ++i) {
+        const Builtins builtin_id = Builtins(i);
+        const std::vector<CallInst*> builtin_call_instances = builtins_call_instances[i];
+        if (builtin_call_instances.empty()) {
+            continue;
+        }
+
+        CallInst* lowered_unique_builtin = nullptr;
+        switch (builtin_id) {
+            case Builtins::workgroup_size_x:
+                lowered_unique_builtin = insert_asm(Builder, Ctx,
+                    ("s_mov_b32 $0, " + std::to_string(tg_dims_[0]) + "; workgroup size x").c_str(), "=s");
+                break;
+            case Builtins::workgroup_size_y:
+                lowered_unique_builtin = insert_asm(Builder, Ctx,
+                    ("s_mov_b32 $0, " + std::to_string(tg_dims_[1]) + "; workgroup size y").c_str(), "=s");
+                break;
+            case Builtins::workgroup_size_z:
+                lowered_unique_builtin = insert_asm(Builder, Ctx,
+                    ("s_mov_b32 $0, " + std::to_string(tg_dims_[2]) + "; workgroup size z").c_str(), "=s");
+                break;
+            default:
+                const auto& assemblyInfo = GetAssemblyInfo(builtin_id);
+                lowered_unique_builtin =
+                    insert_asm(Builder, Ctx, assemblyInfo.asmString, assemblyInfo.asmConstraints);
+        }
+
+        for (CallInst* call_to_builtin : builtin_call_instances) {
+            call_to_builtin->replaceAllUsesWith(lowered_unique_builtin);
+        }
+    }
+
+    for (int i = 0; i < static_cast<int>(builtins_count); ++i) {
+        const std::vector<CallInst*> builtin_call_instances = builtins_call_instances[i];
+        for (CallInst* call_to_builtin : builtin_call_instances) {
+            call_to_builtin->eraseFromParent();
+        }
+    }
+    // All uncalled functions from the module have to be removed because any kernels other than the one
+    // marked as entrypoint may contain calls to builtins which have not been resolved by this pass but
+    // may trip up linkers/relocations. Therefore we set all functions to internal linkage, except the
+    // known entrypoint. This way, the global dead code elimination pass can remove them for us.
+    for (Function& F : M) {
+        if (F.getName().startswith("llvm")) {
+            // Don't mark llvm intrinsics as internal linkage, otherwise they get
+            // altered/removed which breaks backend codegen.
+            continue;
+        }
+        F.setLinkage(GlobalValue::LinkageTypes::InternalLinkage);
+    }
+    entrypoint_fn->setLinkage(GlobalValue::LinkageTypes::ExternalLinkage);
+
+    return PreservedAnalyses::none();
+}

--- a/src/pal/pal_lower_builtins_pass.h
+++ b/src/pal/pal_lower_builtins_pass.h
@@ -1,5 +1,3 @@
-// Copyright (c) 2023 Advanced Micro Devices, Inc. All rights reserved.
-
 #ifndef PAL_PLATFORM_LOWER_BUILTINS_H
 #define PAL_PLATFORM_LOWER_BUILTINS_H
 

--- a/src/pal/pal_lower_builtins_pass.h
+++ b/src/pal/pal_lower_builtins_pass.h
@@ -1,0 +1,37 @@
+// Copyright (c) 2023 Advanced Micro Devices, Inc. All rights reserved.
+
+#ifndef PAL_PLATFORM_LOWER_BUILTINS_H
+#define PAL_PLATFORM_LOWER_BUILTINS_H
+
+#include <llvm/CodeGen/TargetPassConfig.h>
+#include <llvm/IR/LegacyPassManager.h>
+#include <llvm/IR/PassManager.h>
+#include <llvm/Pass.h>
+#include <llvm/Transforms/IPO/PassManagerBuilder.h>
+
+#include <pal.h>
+#include <palDevice.h>
+
+/// This pass takes care of replacing calls to so-called "builtins" (i.e. local/global thread indices, and similar
+/// compute shader builtin values) with the appropriate amdgpu inline assembly that extracts the values from
+/// prepopulated SGPRs according to the RDNA2 or RDNA3 ABI. This pass only supports gfx-levels 10 and 11.
+struct PalPlatformLowerBuiltinsPass : llvm::PassInfoMixin<PalPlatformLowerBuiltinsPass> {
+    PalPlatformLowerBuiltinsPass(
+        Pal::GfxIpLevel gfx_level, std::array<uint64_t, 3> tg_dims)
+        : gfx_level_(gfx_level)
+        , tg_dims_(tg_dims) {}
+
+    PalPlatformLowerBuiltinsPass(const PalPlatformLowerBuiltinsPass& other) = default;
+    PalPlatformLowerBuiltinsPass& operator=(const PalPlatformLowerBuiltinsPass& other) = default;
+    PalPlatformLowerBuiltinsPass(PalPlatformLowerBuiltinsPass&& other) = default;
+    PalPlatformLowerBuiltinsPass& operator=(PalPlatformLowerBuiltinsPass&& other) = default;
+    ~PalPlatformLowerBuiltinsPass() = default;
+
+    llvm::PreservedAnalyses run(llvm::Module& M, llvm::ModuleAnalysisManager&);
+
+private:
+    Pal::GfxIpLevel gfx_level_;
+    std::array<uint64_t, 3> tg_dims_;
+};
+
+#endif // PAL_PLATFORM_LOWER_BUILTINS_H

--- a/src/pal/pal_lower_kernel_arguments_pass.cpp
+++ b/src/pal/pal_lower_kernel_arguments_pass.cpp
@@ -1,5 +1,3 @@
-// Copyright (c) 2023 Advanced Micro Devices, Inc. All rights reserved.
-
 #include "pal_lower_kernel_arguments_pass.h"
 #include "pal_utils.h"
 

--- a/src/pal/pal_lower_kernel_arguments_pass.cpp
+++ b/src/pal/pal_lower_kernel_arguments_pass.cpp
@@ -1,0 +1,247 @@
+// Copyright (c) 2023 Advanced Micro Devices, Inc. All rights reserved.
+
+#include "pal_lower_kernel_arguments_pass.h"
+#include "pal_utils.h"
+
+#include <optional>
+
+#include <llvm/IR/BasicBlock.h>
+#include <llvm/IR/CallingConv.h>
+#include <llvm/IR/Function.h>
+#include <llvm/IR/IRBuilder.h>
+#include <llvm/IR/InlineAsm.h>
+#include <llvm/IR/MDBuilder.h>
+#include <llvm/Support/Alignment.h>
+
+using namespace llvm;
+
+namespace {
+// anonymous namespace to avoid name clashes
+
+// Function taken from llvm-project/llvm/lib/Target/AMDGPU/AMDGPULowerKernelArguments.cpp
+BasicBlock::iterator getInsertPt(BasicBlock& BB) {
+    BasicBlock::iterator InsPt = BB.getFirstInsertionPt();
+    for (BasicBlock::iterator E = BB.end(); InsPt != E; ++InsPt) {
+        AllocaInst* AI = dyn_cast<AllocaInst>(&*InsPt);
+
+        // If this is a dynamic alloca, the value may depend on the loaded kernargs,
+        // so loads will need to be inserted before it.
+        if (!AI || !AI->isStaticAlloca())
+            break;
+    }
+
+    return InsPt;
+}
+
+// Function based on AMDGPUSubtarget::getExplicitKernArgSize(const Function &F, Align &MaxAlign)
+// Taken from llvm-project/llvm/lib/Target/AMDGPU/AMDGPUSubtarget.cpp
+uint64_t getExplicitKernArgSize(const Function& F, Align& MaxAlign) {
+    assert(F.getCallingConv() == CallingConv::AMDGPU_CS);
+
+    const DataLayout& DL = F.getParent()->getDataLayout();
+    uint64_t ExplicitArgBytes = 0;
+    MaxAlign = Align(1);
+
+    for (const Argument& Arg : F.args()) {
+        const bool IsByRef = Arg.hasByRefAttr();
+        Type* ArgTy = IsByRef ? Arg.getParamByRefType() : Arg.getType();
+        MaybeAlign ParamAlign = IsByRef ? Arg.getParamAlign() : std::nullopt;
+        Align ABITypeAlign = DL.getValueOrABITypeAlignment(ParamAlign, ArgTy);
+
+        uint64_t AllocSize = DL.getTypeAllocSize(ArgTy);
+        ExplicitArgBytes = alignTo(ExplicitArgBytes, ABITypeAlign) + AllocSize;
+        MaxAlign = std::max(MaxAlign, ABITypeAlign);
+    }
+
+    return ExplicitArgBytes;
+}
+
+// Function based on AMDGPUSubtarget::getKernArgSegmentSize(const Function &F, Align &MaxAlign)
+// Taken from llvm-project/llvm/lib/Target/AMDGPU/AMDGPUSubtarget.cpp
+unsigned getKernArgSegmentSize(const Function& F, Align& MaxAlign) {
+    uint64_t ExplicitArgBytes = getExplicitKernArgSize(F, MaxAlign);
+    unsigned ExplicitOffset = 0;
+    // Being able to dereference past the end is useful for emitting scalar loads.
+    return alignTo(ExplicitOffset + ExplicitArgBytes, 4);
+}
+} // namespace
+
+// Largely based on the function AMDGPULowerKernelArguments::runOnFunction(Function &F)
+// taken from llvm-project/llvm/lib/Target/AMDGPU/AMDGPULowerKernelArguments.cpp
+// Minor adaptations added to satisfy the AnyDSL PALPlatform requirements.
+PreservedAnalyses PalPlatformLowerKernelArgumentsPass::run(Function& F, FunctionAnalysisManager&) {
+    const auto& funcname = F.getName();
+    if (funcname != pal_utils::ComputeShaderMainFnName || F.arg_empty()) {
+        // Only the entry point function's parameters are kernel arguments that need to be lowered.
+        return PreservedAnalyses::all();
+    }
+    assert(F.getCallingConv() == CallingConv::AMDGPU_CS);
+
+    LLVMContext& Ctx = F.getParent()->getContext();
+    const DataLayout& DL = F.getParent()->getDataLayout();
+    BasicBlock& EntryBlock = *F.begin();
+    IRBuilder<> Builder(&*getInsertPt(EntryBlock));
+
+    const Align KernArgBaseAlign(16); // FIXME: Increase if necessary
+    const uint64_t BaseOffset = 0;    // We don't have any data preceding the kernel arguments
+
+    Align MaxAlign;
+    // TODO: We have to extract that from the Function arguments ourselves!
+    const uint64_t TotalKernArgSize = getKernArgSegmentSize(F, MaxAlign);
+    if (TotalKernArgSize == 0)
+        return PreservedAnalyses::all();
+
+    // Generate Our own ISA to get the pointer to the buffer containing the kernel arguments
+    // PALPlatform ensures that registers s[2:3] contain this address when the kernel starts execution
+    std::string asmString = std::string("; def $0 pointer to buffer containing the kernel args is set up in s[2:3]");
+    // Constraints reference: https://llvm.org/docs/LangRef.html#inline-asm-constraint-string
+    // This constraint states that our inline assembly returns ("="-prefix indicates constraint for output)
+    // its result in sgprs 2-3
+    StringRef constraints = "={s[2:3]}";
+    ArrayRef<Value*> inline_asm_args = std::nullopt;
+
+    // Value taken from AMDGPU.h (namespace AMDGPUAS)
+    // global address space pointing to memory that won't change during execution
+    unsigned CONSTANT_ADDRESS = 4;
+    InlineAsm* inline_assembly =
+        InlineAsm::get(FunctionType::get(Type::getInt8PtrTy(Ctx, CONSTANT_ADDRESS), false), asmString.c_str(),
+            constraints, true, false, InlineAsm::AD_ATT);
+    CallInst* KernArgSegment = Builder.CreateCall(inline_assembly, inline_asm_args);
+
+    KernArgSegment->addRetAttr(Attribute::NonNull);
+    KernArgSegment->addRetAttr(Attribute::getWithDereferenceableBytes(Ctx, TotalKernArgSize));
+    unsigned AS = KernArgSegment->getType()->getPointerAddressSpace();
+
+    uint64_t ExplicitArgOffset = 0;
+
+    for (Argument& Arg : F.args()) {
+        const bool IsByRef = Arg.hasByRefAttr();
+        Type* ArgTy = IsByRef ? Arg.getParamByRefType() : Arg.getType();
+        MaybeAlign ParamAlign = IsByRef ? Arg.getParamAlign() : std::nullopt;
+        Align ABITypeAlign = DL.getValueOrABITypeAlignment(ParamAlign, ArgTy);
+
+        uint64_t Size = DL.getTypeSizeInBits(ArgTy);
+        uint64_t AllocSize = DL.getTypeAllocSize(ArgTy);
+
+        uint64_t EltOffset = alignTo(ExplicitArgOffset, ABITypeAlign) + BaseOffset;
+        ExplicitArgOffset = alignTo(ExplicitArgOffset, ABITypeAlign) + AllocSize;
+
+        if (Arg.use_empty())
+            continue;
+
+        // If this is byval, the loads are already explicit in the function. We just
+        // need to rewrite the pointer values.
+        if (IsByRef) {
+            Value* ArgOffsetPtr = Builder.CreateConstInBoundsGEP1_64(
+                Builder.getInt8Ty(), KernArgSegment, EltOffset, Arg.getName() + ".byval.kernarg.offset");
+
+            Value* CastOffsetPtr = Builder.CreatePointerBitCastOrAddrSpaceCast(ArgOffsetPtr, Arg.getType());
+            Arg.replaceAllUsesWith(CastOffsetPtr);
+            continue;
+        }
+
+        if (PointerType* PT = dyn_cast<PointerType>(ArgTy)) {
+            // FIXME: Hack. We rely on AssertZext to be able to fold DS addressing
+            // modes on SI to know the high bits are 0 so pointer adds don't wrap. We
+            // can't represent this with range metadata because it's only allowed for
+            // integer types.
+
+            // Values taken from AMDGPU.h (namespace AMDGPUAS)
+            const unsigned REGION_ADDRESS = 2; ///< Address space for region memory. (GDS)
+            const unsigned LOCAL_ADDRESS = 3;  ///< Address space for local memory.
+            if ((PT->getAddressSpace() == LOCAL_ADDRESS || PT->getAddressSpace() == REGION_ADDRESS))
+                continue;
+
+            // FIXME: We can replace this with equivalent alias.scope/noalias
+            // metadata, but this appears to be a lot of work.
+            if (Arg.hasNoAliasAttr())
+                continue;
+        }
+
+        auto* VT = dyn_cast<FixedVectorType>(ArgTy);
+        bool IsV3 = VT && VT->getNumElements() == 3;
+        bool DoShiftOpt = Size < 32 && !ArgTy->isAggregateType();
+
+        VectorType* V4Ty = nullptr;
+
+        int64_t AlignDownOffset = alignDown(EltOffset, 4);
+        int64_t OffsetDiff = EltOffset - AlignDownOffset;
+        Align AdjustedAlign = commonAlignment(KernArgBaseAlign, DoShiftOpt ? AlignDownOffset : EltOffset);
+
+        Value* ArgPtr;
+        Type* AdjustedArgTy;
+        if (DoShiftOpt) { // FIXME: Handle aggregate types
+            // Since we don't have sub-dword scalar loads, avoid doing an extload by
+            // loading earlier than the argument address, and extracting the relevant
+            // bits.
+            //
+            // Additionally widen any sub-dword load to i32 even if suitably aligned,
+            // so that CSE between different argument loads works easily.
+            ArgPtr = Builder.CreateConstInBoundsGEP1_64(Builder.getInt8Ty(), KernArgSegment, AlignDownOffset,
+                Arg.getName() + ".kernarg.offset.align.down");
+            AdjustedArgTy = Builder.getInt32Ty();
+        } else {
+            ArgPtr = Builder.CreateConstInBoundsGEP1_64(
+                Builder.getInt8Ty(), KernArgSegment, EltOffset, Arg.getName() + ".kernarg.offset");
+            AdjustedArgTy = ArgTy;
+        }
+
+        if (IsV3 && Size >= 32) {
+            V4Ty = FixedVectorType::get(VT->getElementType(), 4);
+            // Use the hack that clang uses to avoid SelectionDAG ruining v3 loads
+            AdjustedArgTy = V4Ty;
+        }
+
+        ArgPtr = Builder.CreateBitCast(ArgPtr, AdjustedArgTy->getPointerTo(AS), ArgPtr->getName() + ".cast");
+        LoadInst* Load = Builder.CreateAlignedLoad(AdjustedArgTy, ArgPtr, AdjustedAlign);
+        Load->setMetadata(LLVMContext::MD_invariant_load, MDNode::get(Ctx, {}));
+
+        MDBuilder MDB(Ctx);
+
+        if (isa<PointerType>(ArgTy)) {
+            if (Arg.hasNonNullAttr())
+                Load->setMetadata(LLVMContext::MD_nonnull, MDNode::get(Ctx, {}));
+
+            uint64_t DerefBytes = Arg.getDereferenceableBytes();
+            if (DerefBytes != 0) {
+                Load->setMetadata(LLVMContext::MD_dereferenceable,
+                    MDNode::get(Ctx, MDB.createConstant(ConstantInt::get(Builder.getInt64Ty(), DerefBytes))));
+            }
+
+            uint64_t DerefOrNullBytes = Arg.getDereferenceableOrNullBytes();
+            if (DerefOrNullBytes != 0) {
+                Load->setMetadata(LLVMContext::MD_dereferenceable_or_null,
+                    MDNode::get(
+                        Ctx, MDB.createConstant(ConstantInt::get(Builder.getInt64Ty(), DerefOrNullBytes))));
+            }
+
+            auto ParamMaybeAlign = Arg.getParamAlign();
+            if (ParamMaybeAlign.has_value()) {
+                Load->setMetadata(LLVMContext::MD_align,
+                    MDNode::get(Ctx, MDB.createConstant(ConstantInt::get(
+                                         Builder.getInt64Ty(), ParamMaybeAlign.valueOrOne().value()))));
+            }
+        }
+
+        // TODO: Convert noalias arg to !noalias
+
+        if (DoShiftOpt) {
+            Value* ExtractBits = OffsetDiff == 0 ? Load : Builder.CreateLShr(Load, OffsetDiff * 8);
+
+            IntegerType* ArgIntTy = Builder.getIntNTy(Size);
+            Value* Trunc = Builder.CreateTrunc(ExtractBits, ArgIntTy);
+            Value* NewVal = Builder.CreateBitCast(Trunc, ArgTy, Arg.getName() + ".load");
+            Arg.replaceAllUsesWith(NewVal);
+        } else if (IsV3) {
+            Value* Shuf = Builder.CreateShuffleVector(Load, ArrayRef<int>{0, 1, 2}, Arg.getName() + ".load");
+            Arg.replaceAllUsesWith(Shuf);
+        } else {
+            Load->setName(Arg.getName() + ".load");
+            Arg.replaceAllUsesWith(Load);
+        }
+    }
+
+    KernArgSegment->addRetAttr(Attribute::getWithAlignment(Ctx, std::max(KernArgBaseAlign, MaxAlign)));
+
+    return PreservedAnalyses::none();
+}

--- a/src/pal/pal_lower_kernel_arguments_pass.h
+++ b/src/pal/pal_lower_kernel_arguments_pass.h
@@ -1,5 +1,3 @@
-// Copyright (c) 2023 Advanced Micro Devices, Inc. All rights reserved.
-
 #ifndef PAL_PLATFORM_LOWER_KERNEL_ARGUMENTS_H
 #define PAL_PLATFORM_LOWER_KERNEL_ARGUMENTS_H
 

--- a/src/pal/pal_lower_kernel_arguments_pass.h
+++ b/src/pal/pal_lower_kernel_arguments_pass.h
@@ -1,0 +1,26 @@
+// Copyright (c) 2023 Advanced Micro Devices, Inc. All rights reserved.
+
+#ifndef PAL_PLATFORM_LOWER_KERNEL_ARGUMENTS_H
+#define PAL_PLATFORM_LOWER_KERNEL_ARGUMENTS_H
+
+#include <llvm/IR/PassManager.h>
+
+/// This pass replaces accesses to kernel arguments with loads from offsets from a manually supplied buffer
+/// containing these arguments. The pointer to this buffer is expected to be prepopulated into specific sgprs
+/// by the PALPlatform.
+///
+/// This pass is an almost 1:1 replicate of the AMDGPULowerKernelArguments pass
+/// (llvm-project/llvm/lib/Target/AMDGPU/AMDGPULowerKernelArguments.cpp)
+struct PalPlatformLowerKernelArgumentsPass : llvm::PassInfoMixin<PalPlatformLowerKernelArgumentsPass> {
+    PalPlatformLowerKernelArgumentsPass(){}
+
+    PalPlatformLowerKernelArgumentsPass(const PalPlatformLowerKernelArgumentsPass& other) = default;
+    PalPlatformLowerKernelArgumentsPass& operator=(const PalPlatformLowerKernelArgumentsPass& other) = default;
+    PalPlatformLowerKernelArgumentsPass(PalPlatformLowerKernelArgumentsPass&& other) = default;
+    PalPlatformLowerKernelArgumentsPass& operator=(PalPlatformLowerKernelArgumentsPass&& other) = default;
+    ~PalPlatformLowerKernelArgumentsPass() = default;
+
+    llvm::PreservedAnalyses run(llvm::Function& F, llvm::FunctionAnalysisManager& FAM);
+};
+
+#endif // PAL_PLATFORM_LOWER_KERNEL_ARGUMENTS_H

--- a/src/pal/pal_utils.cpp
+++ b/src/pal/pal_utils.cpp
@@ -1,5 +1,3 @@
-// Copyright (c) 2023 Advanced Micro Devices, Inc. All rights reserved.
-
 #include "pal_utils.h"
 
 #include "../runtime.h"

--- a/src/pal/pal_utils.cpp
+++ b/src/pal/pal_utils.cpp
@@ -367,11 +367,11 @@ bool allocation_is_host_visible(Pal::IGpuMemory* gpu_allocation) {
     const Pal::GpuMemoryDesc& memory_desc = gpu_allocation->Desc();
     for (Pal::uint32 i = 0; i < memory_desc.heapCount; ++i) {
         if (memory_desc.heaps[i] == Pal::GpuHeap::GpuHeapInvisible) {
-            return true;
+            return false;
         }
     }
 
-    return false;
+    return true;
 }
 
 ShaderSrc::ShaderSrc(const std::string& filename, const std::string& src_code, const std::string& kernelname)

--- a/src/pal/pal_utils.cpp
+++ b/src/pal/pal_utils.cpp
@@ -363,6 +363,17 @@ Pal::GpuHeap find_gpu_local_heap(const Pal::IDevice* device, Pal::gpusize memory
     return Pal::GpuHeap::GpuHeapCount;
 }
 
+bool allocation_is_host_visible(Pal::IGpuMemory* gpu_allocation) {
+    const Pal::GpuMemoryDesc& memory_desc = gpu_allocation->Desc();
+    for (Pal::uint32 i = 0; i < memory_desc.heapCount; ++i) {
+        if (memory_desc.heaps[i] == Pal::GpuHeap::GpuHeapInvisible) {
+            return true;
+        }
+    }
+
+    return false;
+}
+
 ShaderSrc::ShaderSrc(const std::string& filename, const std::string& src_code, const std::string& kernelname)
     : kernelname(kernelname)
     , src_code(src_code)

--- a/src/pal/pal_utils.cpp
+++ b/src/pal/pal_utils.cpp
@@ -1,0 +1,408 @@
+// Copyright (c) 2023 Advanced Micro Devices, Inc. All rights reserved.
+
+#include "pal_utils.h"
+
+#include "../runtime.h"
+
+#include <g_palPipelineAbiMetadata.h>
+#include <gfx9_plus_merged_offset.h>
+#include <palMetroHash.h>
+#include <palPipelineAbi.h>
+
+#include <llvm/IR/Constants.h>
+#include <llvm/IRReader/IRReader.h>
+
+namespace pal_utils {
+
+std::string llvm_diagnostic_to_string(const llvm::SMDiagnostic& diagnostic_err) {
+    std::string stream;
+    llvm::raw_string_ostream llvm_stream(stream);
+    diagnostic_err.print("", llvm_stream);
+    llvm_stream.flush();
+    return stream;
+}
+
+const char* ComputeShaderMainFnName =
+    Util::Abi::PipelineAbiSymbolNameStrings[static_cast<int>(Util::Abi::PipelineSymbolType::CsMainEntry)];
+
+// clang-format off
+    // Meaning of the different bits taken from: https://llvm.org/docs/AMDGPUUsage.html#amdgpu-amdhsa-compute-pgm-rsrc1-gfx6-gfx11-table
+    // PGM_RSRC1 Register:
+    /*        
+        [5:0]   - GRANULATED_WORKITEM_VGPR_COUNT    -> set to vgpr count / 4 (if wave64) or 8 (if wave32)
+        [9:6]   - GRANULATED_WAVEFRONT_SGPR_COUNT   -> gfx10 and up: must be 0;
+        [11:10] - PRIORITY                          -> must be 0
+        [13:12] - FLOAT_ROUND_MODE_32               -> see: https://llvm.org/docs/AMDGPUUsage.html#amdgpu-amdhsa-floating-point-rounding-mode-enumeration-values-table
+        [15:14] - FLOAT_ROUND_MODE_16_64            -"-
+        [17:16] - FLOAT_DENORM_MODE_32              -> see: -> see: https://llvm.org/docs/AMDGPUUsage.html#amdgpu-amdhsa-floating-point-denorm-mode-enumeration-values-table
+        [19:18] - FLOAT_DENORM_MODE_16_64           -"-
+        [20]    - PRIV                              -> must be 0
+        [21]    - ENABLE_DX10_CLAMP                 -> Dx10 clamp mode on or off
+        [22]    - DEBUG_MODE                        -> must be 0
+        [23]    - ENABLE_IEEE_MODE                  -> IEEE Mode flag
+        [24]    - BULKY                             -> must be 0
+        [25]    - CDBG_USER                         -> must be 0
+        [26]    - FP16_OVFL    // GFX9+             -> overflow mode for fp16
+        [28:27] - RESERVED0                         -> must be 0
+        [29]    - WGP_MODE     // GFX10+            -> 0: waves in CU-mode; 1: waves in WGP-mode
+        [30]    - MEM_ORDERED // GFX10+             -> 0: reports completion of load and atomic out of order; 1: in order
+        [31]    - FWD_PROGRESS // GFX10+            -> 0: SIMD wavefronts oldest first; 1: some forward progress
+    */
+// clang-format on
+struct PGM_RSRC1 {
+    union {
+        struct {
+            uint32_t GRANULATED_WORKITEM_VGPR_COUNT : 6;
+            uint32_t GRANULATED_WAVEFRONT_SGPR_COUNT : 4;
+            uint32_t PRIORITY : 2;
+            uint32_t FLOAT_ROUND_MODE_32 : 2;
+            uint32_t FLOAT_ROUND_MODE_16_64 : 2;
+            uint32_t FLOAT_DENORM_MODE_32 : 2;
+            uint32_t FLOAT_DENORM_MODE_16_64 : 2;
+            uint32_t PRIV : 1;
+            uint32_t ENABLE_DX10_CLAMP : 1;
+            uint32_t DEBUG_MODE : 1;
+            uint32_t ENABLE_IEEE_MODE : 1;
+            uint32_t BULKY : 1;
+            uint32_t CDBG_USER : 1;
+            uint32_t FP16_OVFL : 1;
+            uint32_t RESERVED0 : 2;
+            uint32_t WGP_MODE : 1;
+            uint32_t MEM_ORDERED : 1;
+            uint32_t FWD_PROGRESS : 1;
+        } bits;
+        uint32_t u32All = 0;
+    };
+};
+
+// clang-format off
+    // PGM_RSRC2 Register:
+    /*        
+        [0]     - ENABLE_PRIVATE_SEGMENT                            -> hsa specifics...     
+        [5:1]   - USER_SGPR_COUNT                                   -> total number of requested user data sgprs
+        [6]     - ENABLE_TRAP_HANDLER                               -> must be 0
+        [7]     - ENABLE_SGPR_WORKGROUP_ID_X                        -> enable setup of system sgpr register for x dimension
+        [8]     - ENABLE_SGPR_WORKGROUP_ID_Y                        -> enable setup of system sgpr register for y dimension
+        [9]     - ENABLE_SGPR_WORKGROUP_ID_Z                        -> enable setup of system sgpr register for z dimension
+        [10]    - ENABLE_SGPR_WORKGROUP_INFO                        -> enable setup of system sgpr register for x dimension
+        [12:11] - ENABLE_VGPR_WORKITEM_ID                           -> enable setup of vgprs with workitem id (0: only x, 1: x&y, 2: x&y&z)
+        [13]    - ENABLE_EXCEPTION_ADDRESS_WATCH                    -> must be 0 
+        [14]    - ENABLE_EXCEPTION_MEMORY                           -> must be 0
+        [23:15] - GRANULATED_LDS_SIZE                               -> must be 0
+        [24]    - ENABLE_EXCEPTION_IEEE_754_FP_INVALID_OPERATION    -> wavefront starts with specified exceptions enabled
+        [25]    - ENABLE_EXCEPTION_FP_DENORMAL_SOURCE               
+        [26]    - ENABLE_EXCEPTION_IEEE_754_FP_DIVISION_BY_ZERO
+        [27]    - ENABLE_EXCEPTION_IEEE_754_FP_OVERFLOW
+        [28]    - ENABLE_EXCEPTION_IEEE_754_FP_UNDERFLOW
+        [29]    - ENABLE_EXCEPTION_IEEE_754_FP_INEXACT
+        [30]    - ENABLE_EXCEPTION_INT_DIVIDE_BY_ZERO
+        [31]    - RESERVED0                                         -> must be 0
+    */
+// clang-format on
+struct PGM_RSRC2 {
+    union {
+        struct {
+            uint32_t ENABLE_PRIVATE_SEGMENT : 1;
+            uint32_t USER_SGPR_COUNT : 5;
+            uint32_t ENABLE_TRAP_HANDLER : 1;
+            uint32_t ENABLE_SGPR_WORKGROUP_ID_X : 1;
+            uint32_t ENABLE_SGPR_WORKGROUP_ID_Y : 1;
+            uint32_t ENABLE_SGPR_WORKGROUP_ID_Z : 1;
+            uint32_t ENABLE_SGPR_WORKGROUP_INFO : 1;
+            uint32_t ENABLE_VGPR_WORKITEM_ID : 2;
+            uint32_t ENABLE_EXCEPTION_ADDRESS_WATCH : 1;
+            uint32_t ENABLE_EXCEPTION_MEMORY : 1;
+            uint32_t GRANULATED_LDS_SIZE : 9;
+            uint32_t ENABLE_EXCEPTION_IEEE_754_FP_INVALID_OPERATION : 1;
+            uint32_t ENABLE_EXCEPTION_FP_DENORMAL_SOURCE : 1;
+            uint32_t ENABLE_EXCEPTION_IEEE_754_FP_DIVISION_BY_ZERO : 1;
+            uint32_t ENABLE_EXCEPTION_IEEE_754_FP_OVERFLOW : 1;
+            uint32_t ENABLE_EXCEPTION_IEEE_754_FP_UNDERFLOW : 1;
+            uint32_t ENABLE_EXCEPTION_IEEE_754_FP_INEXACT : 1;
+            uint32_t ENABLE_EXCEPTION_INT_DIVIDE_BY_ZERO : 1;
+            uint32_t RESERVED0 : 1;
+        } bits;
+        uint32_t u32All = 0;
+    };
+};
+
+llvm::StringRef get_metadata_string(const llvm::Function* func, const char* key) {
+    return llvm::cast<llvm::MDString>(func->getMetadata(key)->getOperand(0))->getString();
+}
+
+uint64_t get_metadata_uint(const llvm::Function* func, const char* key, int index) {
+    llvm::MDNode* node = func->getMetadata(key);
+
+    llvm::Metadata* the_data = node->getOperand(index).get();
+
+    // Level of indirection due to how llvm uniques metadata nodes
+    if (llvm::MDTuple::classof(the_data)) {
+        const llvm::MDTuple* md_tuple = static_cast<llvm::MDTuple*>(the_data);
+        assert(md_tuple->getNumOperands() == 1);
+        the_data = md_tuple->getOperand(0).get();
+    }
+
+    assert(llvm::ConstantAsMetadata::classof(the_data));
+    // First cast to the appropriate Metadata type
+    const llvm::ConstantAsMetadata* md_constant = static_cast<llvm::ConstantAsMetadata*>(the_data);
+    // Then cast to the constant type (which we know to be unsigned int)
+    const llvm::ConstantInt* constant = static_cast<llvm::ConstantInt*>(md_constant->getValue());
+    // Return the constant's value as an unsigned int
+    return constant->getZExtValue();
+}
+
+llvm::MDNode* get_metadata_mdnode(const llvm::Function* func, const char* key, int index) {
+    return llvm::cast<llvm::MDNode>(func->getMetadata(key)->getOperand(index));
+}
+
+llvm::msgpack::Document build_metadata(const ShaderSrc& shader_src, Pal::GfxIpLevel gfx_level,
+    const std::array<uint64_t, 3>& thread_group_dimensions, uint32_t wavefront_size) {
+    llvm::msgpack::Document document;
+
+    // Add the metadata version number.
+    auto versionNode =
+        document.getRoot().getMap(true)[Util::PalAbi::CodeObjectMetadataKey::Version].getArray(true);
+    versionNode[0] = Util::PalAbi::PipelineMetadataMajorVersion;
+    versionNode[1] = Util::PalAbi::PipelineMetadataMinorVersion;
+
+    auto pipelinesNode =
+        document.getRoot().getMap(true)[Util::PalAbi::CodeObjectMetadataKey::Pipelines].getArray(true);
+    auto pipeline_node = pipelinesNode[0].getMap(true);
+    pipeline_node[Util::PalAbi::PipelineMetadataKey::Api].fromString("Vulkan");
+    pipeline_node[Util::PalAbi::PipelineMetadataKey::Type].fromString("Cs");
+    // ".cs" taken from "pal/inc/core/g_palPipelineAbiMetadataImpl.h" SerializeEnum()
+    auto compute_hwstage_node =
+        pipeline_node[Util::PalAbi::PipelineMetadataKey::HardwareStages].getMap(true)[".cs"].getMap(true);
+    auto tg_dims_node =
+        compute_hwstage_node[Util::PalAbi::HardwareStageMetadataKey::ThreadgroupDimensions].getArray(true);
+    tg_dims_node[0] = thread_group_dimensions[0];
+    tg_dims_node[1] = thread_group_dimensions[1];
+    tg_dims_node[2] = thread_group_dimensions[2];
+
+    compute_hwstage_node[Util::PalAbi::HardwareStageMetadataKey::WavefrontSize] = wavefront_size;
+    // Values can be found in llpc/lgc/state/TargetInfo.cpp
+    // (https://github.com/GPUOpen-Drivers/llpc/blob/dev/lgc/state/TargetInfo.cpp)
+    compute_hwstage_node[Util::PalAbi::HardwareStageMetadataKey::SgprLimit] = 102;
+    compute_hwstage_node[Util::PalAbi::HardwareStageMetadataKey::VgprLimit] = 256;
+
+    Util::MetroHash::Hash hash = {};
+    Util::MetroHash64::Hash(reinterpret_cast<const uint8_t*>(shader_src.src_code.c_str()), shader_src.src_code.length(), hash.bytes);
+
+    uint64_t hash_compacted =
+        Util::MetroHash::Compact64(reinterpret_cast<const Util::MetroHash::Hash*>(&hash));
+    uint32_t hash_lower = 0xFFFFFFFF & hash_compacted;
+    uint32_t hash_upper = hash_compacted >> 32;
+
+    auto pipelineHash =
+        pipeline_node.getMap(true)[Util::PalAbi::PipelineMetadataKey::InternalPipelineHash].getArray(true);
+    pipelineHash[0] = hash_lower;
+    pipelineHash[1] = hash_upper;
+
+    auto registers_node = pipeline_node[".registers"].getMap(true);
+
+    auto getKeyAsDocNode = [&document](unsigned int key) {
+        auto key_doc_node = document.getEmptyNode();
+        key_doc_node = key;
+        return key_doc_node;
+    };
+
+    registers_node[getKeyAsDocNode(Pal::Gfx9::Chip::mmCOMPUTE_NUM_THREAD_X)] = thread_group_dimensions[0];
+    registers_node[getKeyAsDocNode(Pal::Gfx9::Chip::mmCOMPUTE_NUM_THREAD_Y)] = thread_group_dimensions[1];
+    registers_node[getKeyAsDocNode(Pal::Gfx9::Chip::mmCOMPUTE_NUM_THREAD_Z)] = thread_group_dimensions[2];
+
+    // Setup the resource registers according to:
+    // https://github.com/GPUOpen-Drivers/llpc/blob/65016996d7c9ad421b4d04a2364dbb1d8f1f7f34/lgc/patch/Gfx9ConfigBuilder.cpp#L1880
+    PGM_RSRC1 register_value_pgm_rsrc1 = {};
+    register_value_pgm_rsrc1.bits.ENABLE_DX10_CLAMP = 1; // Follow PAL setting
+    register_value_pgm_rsrc1.bits.MEM_ORDERED = 1;       // Follow LLPC setting
+
+    PGM_RSRC2 register_value_pgm_rsrc2 = {};
+    // PAL SGPR layout:
+    // s0-1: PAL reserved data
+    // s2-3: pointer to pal kernel args
+    // s4-5: pointer to NumWorkGroups struct (i.e., nblk)
+    // s6-12: reserved for future use
+    // s13: block id x
+    // s14: block id y
+    // s15: block id z
+    register_value_pgm_rsrc2.bits.USER_SGPR_COUNT = 13; // Don't count s13-15 as these are set up by hardware
+
+    register_value_pgm_rsrc2.bits.ENABLE_SGPR_WORKGROUP_ID_X = 1;
+    register_value_pgm_rsrc2.bits.ENABLE_SGPR_WORKGROUP_ID_Y = 1;
+    register_value_pgm_rsrc2.bits.ENABLE_SGPR_WORKGROUP_ID_Z = 1;
+
+    register_value_pgm_rsrc2.bits.ENABLE_VGPR_WORKITEM_ID = 2; // 0 = X, 1 = XY, 2 = XYZ
+
+    registers_node[getKeyAsDocNode(Pal::Gfx9::Chip::mmCOMPUTE_PGM_RSRC1)] = register_value_pgm_rsrc1.u32All;
+    registers_node[getKeyAsDocNode(Pal::Gfx9::Chip::mmCOMPUTE_PGM_RSRC2)] = register_value_pgm_rsrc2.u32All;
+
+    if (gfx_level > Pal::GfxIpLevel::GfxIp9) {
+        // RSRC3 doesn't contain values we are interested in for now, can all be 0 for us.
+        uint32_t register_value_pgm_rsrc3 = 0;
+        registers_node[getKeyAsDocNode(Pal::Gfx9::Chip::Gfx10Plus::mmCOMPUTE_PGM_RSRC3)] =
+            register_value_pgm_rsrc3;
+
+        uint32_t shader_checksum = hash_upper ^ hash_lower;
+        registers_node[getKeyAsDocNode(Pal::Gfx9::Chip::Gfx10Plus::mmCOMPUTE_SHADER_CHKSUM)] =
+            shader_checksum;
+    }
+
+    // Default SGPR setup
+    // Let PAL set up user data 0 & 1-> PAL Global Table Pointer
+    registers_node[getKeyAsDocNode(Pal::Gfx9::Chip::mmCOMPUTE_USER_DATA_0)] =
+        static_cast<uint32_t>(Util::Abi::UserDataMapping::GlobalTable);
+
+    // PALPlatform set up pointer to a struct containing the actual kernel arguments
+    registers_node[getKeyAsDocNode(Pal::Gfx9::Chip::mmCOMPUTE_USER_DATA_2)] = 0;
+    registers_node[getKeyAsDocNode(Pal::Gfx9::Chip::mmCOMPUTE_USER_DATA_3)] = 1;
+
+    // Let PAL set up user data 4 & 5 -> PAL Num Work Group Pointer
+    registers_node[getKeyAsDocNode(Pal::Gfx9::Chip::mmCOMPUTE_USER_DATA_4)] =
+        static_cast<uint32_t>(Util::Abi::UserDataMapping::Workgroup);
+
+    return document;
+}
+
+// This function is taken from llvm-project/llvm/lib/Target/AMDGPU/Utils/AMDGPUBaseInfo.cpp
+bool isAMDGPUEntryFunctionCC(llvm::CallingConv::ID CC) {
+    switch (CC) {
+        case llvm::CallingConv::AMDGPU_KERNEL:
+        case llvm::CallingConv::SPIR_KERNEL:
+        case llvm::CallingConv::AMDGPU_VS:
+        case llvm::CallingConv::AMDGPU_GS:
+        case llvm::CallingConv::AMDGPU_PS:
+        case llvm::CallingConv::AMDGPU_CS:
+        case llvm::CallingConv::AMDGPU_ES:
+        case llvm::CallingConv::AMDGPU_HS:
+        case llvm::CallingConv::AMDGPU_LS: return true;
+        default: return false;
+    }
+}
+
+inline void check_pal_error(Pal::Result err, const char* name, const char* file, const int line) {
+    if (err != Pal::Result::Success) {
+        error("PAL API function % [file %, line %]: %", name, file, line, static_cast<int32_t>(err));
+    }
+}
+
+void write_to_memory(
+    Pal::IGpuMemory* dst_memory, int64_t dst_memory_offset, const void* src_data, int64_t size) {
+    void* mapped_dst = nullptr;
+    Pal::Result result = dst_memory->Map(&mapped_dst);
+    CHECK_PAL(result, "write_to_memory | Map()");
+
+    std::memcpy(static_cast<uint8_t*>(mapped_dst) + dst_memory_offset, src_data, size);
+
+    result = dst_memory->Unmap();
+    CHECK_PAL(result, "write_to_memory | Unmap()");
+}
+
+void read_from_memory(void* dst_buffer, Pal::IGpuMemory* src_memory, int64_t src_memory_offset, int64_t size) {
+    void* mapped_src = nullptr;
+    Pal::Result result = src_memory->Map(&mapped_src);
+    CHECK_PAL(result, "read_to_buffer | Map()");
+
+    std::memcpy(dst_buffer, static_cast<uint8_t*>(mapped_src) + src_memory_offset, size);
+
+    result = src_memory->Unmap();
+    CHECK_PAL(result, "read_to_buffer | Unmap()");
+}
+
+const char* get_gpu_name(const Pal::AsicRevision asic_revision) {
+    // We don't support cards prior to the "Navi" generations
+    switch (asic_revision) {
+        case Pal::AsicRevision::Unknown: return "Unknown";
+        case Pal::AsicRevision::Navi10: return "Navi10";
+#if PAL_BUILD_NAVI12
+        case Pal::AsicRevision::Navi12: return "Navi12";
+#endif
+#if PAL_BUILD_NAVI14
+        case Pal::AsicRevision::Navi14: return "Navi14";
+#endif
+        case Pal::AsicRevision::Navi21: return "Navi21";
+        case Pal::AsicRevision::Navi22: return "Navi22";
+        case Pal::AsicRevision::Navi23: return "Navi23";
+#if PAL_BUILD_NAVI24
+        case Pal::AsicRevision::Navi24: return "Navi24";
+#endif
+#if PAL_BUILD_NAVI31
+        case Pal::AsicRevision::Navi31: return "Navi31";
+#endif
+        default: return "Unknown";
+    }
+}
+
+const char* get_gfx_isa_id(const Pal::GfxIpLevel gfxip_level) {
+    // We can only deal with gfxip capable devices!
+    assert(gfxip_level != Pal::GfxIpLevel::_None);
+
+    // We don't support cards prior to gfx10
+    switch (gfxip_level) {
+        case Pal::GfxIpLevel::GfxIp10_1: return "gfx1010";
+        case Pal::GfxIpLevel::GfxIp10_3: return "gfx1030";
+#if PAL_BUILD_GFX11
+        case Pal::GfxIpLevel::GfxIp11_0: return "gfx1100";
+#endif
+        default: assert(false);
+    }
+}
+
+Pal::GpuHeap find_gpu_local_heap(const Pal::IDevice* device, Pal::gpusize memory_size) {
+    Pal::GpuMemoryHeapProperties heap_properties[Pal::GpuHeapCount] = {};
+    Pal::Result result = device->GetGpuMemoryHeapProperties(heap_properties);
+    CHECK_PAL(result, "GetGpuMemoryHeapProperties()");
+
+    if (heap_properties[Pal::GpuHeap::GpuHeapInvisible].logicalSize >= memory_size) {
+        return Pal::GpuHeap::GpuHeapInvisible;
+    } else if (heap_properties[Pal::GpuHeap::GpuHeapLocal].logicalSize >= memory_size) {
+        return Pal::GpuHeap::GpuHeapLocal;
+    }
+
+    assert(
+        false && "Memory could not be allocated on either local or invisible heap of GPU. (Heaps to small)");
+    return Pal::GpuHeap::GpuHeapCount;
+}
+
+ShaderSrc::ShaderSrc(const std::string& filename, const std::string& src_code, const std::string& kernelname)
+    : kernelname(kernelname)
+    , src_code(src_code)
+    , filename(filename)
+    , function(nullptr) {
+    this->llvm_module = llvm::parseIR(llvm::MemoryBuffer::getMemBuffer(src_code)->getMemBufferRef(), diagnostic_err, llvm_context);
+    if (!llvm_module)
+        error("Parsing kernel % from IR file %:\n%", kernelname, filename,
+            llvm_diagnostic_to_string(diagnostic_err));
+    for (const llvm::Function& func : *llvm_module) {
+        const auto& funcname = func.getName();
+        if (funcname == kernelname) {
+            this->function = &func;
+        }
+    }
+    assert(this->function != nullptr && "Can't find kernel function");
+}
+
+// Finds the given shader entry point and renames it to match PAL's fixed naming requirements for pipeline
+// functions. It further sets all other functions that the AMDGPU LLVM backend would recognize as entry points
+// to a calling convention that's not recognized as an entry point.
+// Returns false if no entry point could be found.
+bool ShaderSrc::rename_entry_point() {
+    bool entry_point_found = false;
+    for (llvm::Function& func : *llvm_module) {
+        const auto& funcname = func.getName();
+        if (funcname == kernelname) {
+            assert(!entry_point_found && "Mustn't have two entry points with the same name in one module!");
+            assert(pal_utils::isAMDGPUEntryFunctionCC(func.getCallingConv()));
+            func.setName(pal_utils::ComputeShaderMainFnName);
+            entry_point_found = true;
+        } else if (pal_utils::isAMDGPUEntryFunctionCC(func.getCallingConv())) {
+            // Any other function that the AMDGPU backend would detect as an entry function must get a
+            // different calling convention, so that only the actual entry point for the current kernel has
+            // the according calling convention.
+            func.setCallingConv(llvm::CallingConv::AMDGPU_Gfx);
+            assert(!pal_utils::isAMDGPUEntryFunctionCC(func.getCallingConv()));
+        }
+    }
+    return entry_point_found;
+}
+
+} // namespace pal_utils

--- a/src/pal/pal_utils.h
+++ b/src/pal/pal_utils.h
@@ -50,6 +50,8 @@ void read_from_memory(void* dst_buffer, Pal::IGpuMemory* src_memory, int64_t src
 // Returns Pal::GpuHeap::GpuHeapCount if no appropriate heap can be found.
 Pal::GpuHeap find_gpu_local_heap(const Pal::IDevice* device, Pal::gpusize memory_size);
 
+bool allocation_is_host_visible(Pal::IGpuMemory* gpu_allocation);
+
 llvm::MDNode* get_metadata_mdnode(const llvm::Function* func, const char* key, int index = 0);
 llvm::StringRef get_metadata_string(const llvm::Function* func, const char* key);
 uint64_t get_metadata_uint(const llvm::Function* func, const char* key, int index = 0);

--- a/src/pal/pal_utils.h
+++ b/src/pal/pal_utils.h
@@ -39,8 +39,6 @@ const char* get_gfx_isa_id(const Pal::GfxIpLevel gfxip_level);
 
 bool isAMDGPUEntryFunctionCC(llvm::CallingConv::ID CC);
 
-void check_pal_error(Pal::Result err, const char* name, const char* file, const int line);
-
 void write_to_memory(
     Pal::IGpuMemory* dst_memory, int64_t dst_memory_offset, const void* src_data, int64_t size);
 void read_from_memory(void* dst_buffer, Pal::IGpuMemory* src_memory, int64_t src_memory_offset, int64_t size);
@@ -60,6 +58,6 @@ extern const char* ComputeShaderMainFnName;
 
 } // namespace pal_utils
 
-#define CHECK_PAL(err, name) pal_utils::check_pal_error(err, name, __FILE__, __LINE__)
+#define CHECK_PAL(err, name) { if (err != Pal::Result::Success) { error("PAL API function % [file %, line %]: %", name, __FILE__, __LINE__, static_cast<int32_t>(err)); } }
 
 #endif

--- a/src/pal/pal_utils.h
+++ b/src/pal/pal_utils.h
@@ -1,4 +1,3 @@
-// Copyright (c) 2023 Advanced Micro Devices, Inc. All rights reserved.
 #ifndef PAL_UTILS_H
 #define PAL_UTILS_H
 

--- a/src/pal/pal_utils.h
+++ b/src/pal/pal_utils.h
@@ -1,0 +1,63 @@
+// Copyright (c) 2023 Advanced Micro Devices, Inc. All rights reserved.
+#ifndef PAL_UTILS_H
+#define PAL_UTILS_H
+
+#include <pal.h>
+#include <palDevice.h>
+
+#include <llvm/BinaryFormat/MsgPackDocument.h>
+#include <llvm/IR/CallingConv.h>
+#include <llvm/IR/Function.h>
+#include <llvm/IR/LLVMContext.h>
+#include <llvm/IR/Module.h>
+#include <llvm/Support/SourceMgr.h>
+
+namespace pal_utils {
+
+std::string llvm_diagnostic_to_string(const llvm::SMDiagnostic& diagnostic_err);
+
+struct ShaderSrc {
+    const std::string kernelname;
+    const std::string src_code;
+    const std::string filename;
+    const llvm::Function* function;
+    llvm::LLVMContext llvm_context;
+    std::unique_ptr<llvm::Module> llvm_module;
+    llvm::SMDiagnostic diagnostic_err;
+
+    ShaderSrc(const std::string& filename, const std::string& src_code, const std::string& kernelname);
+    bool rename_entry_point();
+};
+
+// Create the metadata that PAL expects to be attached to a kernel/shader binary.
+llvm::msgpack::Document build_metadata(const ShaderSrc& shader_src, Pal::GfxIpLevel gfx_level,
+    const std::array<uint64_t, 3>& thread_group_dimensions, uint32_t wavefront_size);
+
+const char* get_gpu_name(const Pal::AsicRevision asic_revision);
+
+const char* get_gfx_isa_id(const Pal::GfxIpLevel gfxip_level);
+
+bool isAMDGPUEntryFunctionCC(llvm::CallingConv::ID CC);
+
+void check_pal_error(Pal::Result err, const char* name, const char* file, const int line);
+
+void write_to_memory(
+    Pal::IGpuMemory* dst_memory, int64_t dst_memory_offset, const void* src_data, int64_t size);
+void read_from_memory(void* dst_buffer, Pal::IGpuMemory* src_memory, int64_t src_memory_offset, int64_t size);
+
+// Returns a gpu-local memory heap that fits memory_size.
+// Order of importance: 1.GpuHeapInvisible, 2.GpuHeapLocal
+// Returns Pal::GpuHeap::GpuHeapCount if no appropriate heap can be found.
+Pal::GpuHeap find_gpu_local_heap(const Pal::IDevice* device, Pal::gpusize memory_size);
+
+llvm::MDNode* get_metadata_mdnode(const llvm::Function* func, const char* key, int index = 0);
+llvm::StringRef get_metadata_string(const llvm::Function* func, const char* key);
+uint64_t get_metadata_uint(const llvm::Function* func, const char* key, int index = 0);
+
+extern const char* ComputeShaderMainFnName;
+
+} // namespace pal_utils
+
+#define CHECK_PAL(err, name) pal_utils::check_pal_error(err, name, __FILE__, __LINE__)
+
+#endif

--- a/src/pal_platform.cpp
+++ b/src/pal_platform.cpp
@@ -174,7 +174,7 @@ void* PALPlatform::alloc(DeviceId dev, int64_t size) {
 
 void* PALPlatform::alloc_host(DeviceId dev, int64_t size) {
     auto& device = devices_[dev];
-    return reinterpret_cast<void*>(device.allocate_gpu_memory(size, Pal::GpuHeap::GpuHeapGartUswc));
+    return reinterpret_cast<void*>(device.allocate_gpu_memory(size, Pal::GpuHeap::GpuHeapGartCacheable));
 }
 
 void* PALPlatform::alloc_unified(DeviceId dev, int64_t size) {

--- a/src/pal_platform.cpp
+++ b/src/pal_platform.cpp
@@ -231,8 +231,7 @@ void PALPlatform::launch_kernel(DeviceId dev, const LaunchParams& launch_params)
 }
 
 void PALPlatform::synchronize(DeviceId dev) {
-    Pal::Result result = devices_[dev].queue_->WaitIdle();
-    CHECK_PAL(result, "WaitIdle()");
+    devices_[dev].WaitIdle();
 }
 
 void PALPlatform::copy(DeviceId dev_src, const void* src, int64_t offset_src, DeviceId dev_dst, void* dst,

--- a/src/pal_platform.cpp
+++ b/src/pal_platform.cpp
@@ -1,5 +1,3 @@
-// Copyright (c) 2023 Advanced Micro Devices, Inc. All rights reserved.
-
 #include "pal_platform.h"
 #include "pal/pal_fix_calling_convention_pass.h"
 #include "pal/pal_insert_halt_pass.h"

--- a/src/pal_platform.cpp
+++ b/src/pal_platform.cpp
@@ -45,21 +45,20 @@
 
 namespace llvm_utils {
 
-// Initializes llvm with amdgpu using the following commandline options:
-// ANYDSL_LLVM_ARGS="-<custom_llvm_args> -amdgpu-sroa -amdgpu-load-store-vectorizer
-// -amdgpu-scalarize-global-loads -amdgpu-internalize-symbols
-// -amdgpu-early-inline-all -amdgpu-sdwa-peephole -amdgpu-dpp-combine
-// -enable-amdgpu-aa -amdgpu-late-structurize=0 -amdgpu-function-calls
-// -amdgpu-simplify-libcall -amdgpu-ir-lower-kernel-arguments
-// -amdgpu-atomic-optimizations -amdgpu-mode-register"
+// Initializes llvm with amdgpu using the passed in commandline options,
+// as well as any further options set through the ANYDSL_LLVM_ARGS env variable.
 void initialize_amdgpu(std::vector<std::string> custom_llvm_args) {
-    const char* env_var = std::getenv("ANYDSL_LLVM_ARGS");
+    // Useful options: ANYDSL_LLVM_ARGS ="-amdgpu-sroa -amdgpu-load-store-vectorizer -amdgpu-scalarize-global-loads -amdgpu-internalize-symbols -amdgpu-early-inline-all -amdgpu-sdwa-peephole -amdgpu-dpp-combine -enable-amdgpu-aa -amdgpu-late-structurize=0 -amdgpu-function-calls -amdgpu-simplify-libcall -amdgpu-ir-lower-kernel-arguments -amdgpu-atomic-optimizations -amdgpu-mode-register"
+    // See: https://anydsl.github.io/Device-Code-Generation-and-Execution.html#amdgpu-code-generation-optimization
+    const char* env_var = std::getenv("ANYDSL_LLVM_ARGS");    
     if (env_var) {
-        std::vector<const char*> c_llvm_args;
         std::istringstream stream(env_var);
         std::string tmp;
         while (stream >> tmp)
             custom_llvm_args.push_back(tmp);
+    }
+    if (!custom_llvm_args.empty()) {
+        std::vector<const char*> c_llvm_args;
         for (auto& str : custom_llvm_args)
             c_llvm_args.push_back(str.c_str());
         llvm::cl::ParseCommandLineOptions(c_llvm_args.size(), c_llvm_args.data(), "AnyDSL gcn JIT compiler\n");

--- a/src/pal_platform.cpp
+++ b/src/pal_platform.cpp
@@ -1,0 +1,517 @@
+// Copyright (c) 2023 Advanced Micro Devices, Inc. All rights reserved.
+
+#include "pal_platform.h"
+#include "pal/pal_fix_calling_convention_pass.h"
+#include "pal/pal_insert_halt_pass.h"
+#include "pal/pal_lower_builtins_pass.h"
+#include "pal/pal_lower_kernel_arguments_pass.h"
+#include "pal/pal_utils.h"
+#include "runtime.h"
+
+#include <algorithm>
+#include <atomic>
+#include <cstring>
+#include <filesystem>
+#include <iterator>
+#include <sstream>
+#include <string>
+#include <thread>
+
+#include <palPipelineAbi.h>
+
+#ifdef AnyDSL_runtime_HAS_LLVM_SUPPORT
+#include <lld/Common/Driver.h>
+#include <llvm/IR/LLVMContext.h>
+#include <llvm/IR/LegacyPassManager.h>
+#include <llvm/IR/Module.h>
+#include <llvm/IRReader/IRReader.h>
+#include <llvm/Linker/Linker.h>
+#include <llvm/MC/TargetRegistry.h>
+#include <llvm/Passes/OptimizationLevel.h>
+#include <llvm/Passes/PassBuilder.h>
+#include <llvm/Support/CommandLine.h>
+#include <llvm/Support/SourceMgr.h>
+#include <llvm/Support/TargetSelect.h>
+#include <llvm/Support/raw_os_ostream.h>
+#include <llvm/Target/TargetMachine.h>
+#include <llvm/Target/TargetOptions.h>
+#include <llvm/Transforms/IPO.h>
+#include <llvm/Transforms/IPO/GlobalDCE.h>
+#include <llvm/Transforms/IPO/PassManagerBuilder.h>
+#include <llvm/Transforms/Utils/Cloning.h>
+#endif
+
+namespace llvm_utils {
+
+void initialize_amdgpu(std::vector<std::string> custom_llvm_args) {
+    const char* env_var = std::getenv("ANYDSL_LLVM_ARGS");
+    if (env_var) {
+        std::vector<const char*> c_llvm_args;
+        std::istringstream stream(env_var);
+        std::string tmp;
+        while (stream >> tmp)
+            custom_llvm_args.push_back(tmp);
+        for (auto& str : custom_llvm_args)
+            c_llvm_args.push_back(str.c_str());
+        llvm::cl::ParseCommandLineOptions(c_llvm_args.size(), c_llvm_args.data(), "AnyDSL gcn JIT compiler\n");
+    }
+    LLVMInitializeAMDGPUTarget();
+    LLVMInitializeAMDGPUTargetInfo();
+    LLVMInitializeAMDGPUTargetMC();
+    LLVMInitializeAMDGPUAsmParser();
+    LLVMInitializeAMDGPUAsmPrinter();
+}
+
+std::unique_ptr<llvm::TargetMachine> create_target_machine(
+    const std::string& target_triple, const std::string& cpu) {
+    std::string error_str;
+    auto target = llvm::TargetRegistry::lookupTarget(target_triple, error_str);
+    llvm::TargetOptions options;
+    options.AllowFPOpFusion = llvm::FPOpFusion::Fast;
+    options.NoTrappingFPMath = true;
+    std::string attrs = "-trap-handler";
+    return std::unique_ptr<llvm::TargetMachine>(target->createTargetMachine(target_triple, cpu, attrs,
+        options, llvm::Reloc::PIC_, llvm::CodeModel::Small, llvm::CodeGenOpt::Aggressive));
+}
+
+void add_module_impl(std::unique_ptr<llvm::Module> module, const llvm::DataLayout& machine_data_layout,
+    llvm::Linker& base_module, llvm::Linker::Flags flags, const llvm::SMDiagnostic& diagnostic_err,
+    const char* module_name) {
+    if (!module)
+        error("Can't create module for '%':\n%", module_name, pal_utils::llvm_diagnostic_to_string(diagnostic_err));
+    // override data layout with the one coming from the target machine
+    module->setDataLayout(machine_data_layout);
+
+    if (base_module.linkInModule(std::move(module), flags))
+        error("Can't link '%' into module.", module_name);
+}
+
+void add_module(llvm::Linker& base_module, const std::string& module_file_path,
+    const llvm::DataLayout& machine_data_layout, llvm::LLVMContext& llvm_context, llvm::Linker::Flags flags) {
+    llvm::SMDiagnostic diagnostic_err;
+    std::unique_ptr<llvm::Module> module(llvm::parseIRFile(module_file_path, diagnostic_err, llvm_context));
+    add_module_impl(std::move(module), machine_data_layout, base_module, flags, diagnostic_err, module_file_path.c_str());
+}
+
+void add_module(llvm::Linker& base_module, const llvm::MemoryBufferRef& module_data_ref,
+    const llvm::DataLayout& machine_data_layout, llvm::LLVMContext& llvm_context, llvm::Linker::Flags flags,
+    const char* module_name) {
+    llvm::SMDiagnostic diagnostic_err;
+    std::unique_ptr<llvm::Module> module = llvm::parseIR(module_data_ref, diagnostic_err, llvm_context);
+    add_module_impl(std::move(module), machine_data_layout, base_module, flags, diagnostic_err, module_name);
+}
+
+} // namespace llvm_utils
+
+// Initializes the root platform object.
+Pal::Result pal_init_platform(Pal::IPlatform** platform) {
+    Pal::PlatformCreateInfo create_info = {};
+    create_info.pAllocCb = nullptr;       // No allocation callbacks - just let PAL call
+                                          // malloc() and free() directly.
+    create_info.pSettingsPath = "Vulkan"; // Read settings from Vulkan's location
+
+    // To support alloc_unified() we need SVM mode.
+    create_info.flags.enableSvmMode = 1;
+    // Reserve address space for 64 GiB - just like the OpenCL driver does.
+    create_info.maxSvmSize = static_cast<Pal::gpusize>(64ll * 1024ll * 1024ll * 1024ll);
+
+    Pal::Result result = Pal::CreatePlatform(create_info, malloc(Pal::GetPlatformSize()), platform);
+
+    Pal::PlatformProperties properties = {};
+
+    if (result == Pal::Result::Success) {
+        result = (*platform)->GetProperties(&properties);
+    }
+
+    return result;
+}
+
+PALPlatform::PALPlatform(Runtime* runtime)
+    : Platform(runtime) {
+    Pal::Result result = pal_init_platform(&platform_);
+    CHECK_PAL(result, "pal_init_platform()");
+
+    // Get a list of all available devices.
+    Pal::IDevice* pal_devices[Pal::MaxDevices] = {};
+    Pal::uint32 device_count = 0;
+    result = platform_->EnumerateDevices(&device_count, pal_devices);
+    if (device_count <= 0) {
+        // This will happen if there are no supported GPUs: PAL only supports SI and newer.
+        result = Pal::Result::ErrorUnavailable;
+    }
+    CHECK_PAL(result, "EnumerateDevices()");
+
+    // Initialize devices.
+    for (Pal::uint32 i = 0; i < device_count; ++i) {
+        Pal::DeviceProperties device_properties;
+        if (Pal::Result::Success == pal_devices[i]->GetProperties(&device_properties)) {
+            if (device_properties.gpuType != Pal::GpuType::Discrete) {
+                // We ignore non-discrete GPUs
+                continue;
+            }
+        }
+
+        devices_.emplace_back(pal_devices[i]);
+    }
+}
+
+PALPlatform::~PALPlatform() {
+    devices_.clear();
+    if (platform_ != nullptr) {
+        platform_->Destroy();
+        free(platform_);
+    }
+}
+
+void* PALPlatform::alloc(DeviceId dev, int64_t size) {
+    auto& device = devices_[dev];
+    Pal::GpuHeap target_heap = pal_utils::find_gpu_local_heap(device.device_, size);
+    if (target_heap == Pal::GpuHeap::GpuHeapCount) {
+        return nullptr;
+    }
+    return reinterpret_cast<void*>(device.allocate_gpu_memory(size, target_heap));
+}
+
+void* PALPlatform::alloc_host(DeviceId dev, int64_t size) {
+    auto& device = devices_[dev];
+    return reinterpret_cast<void*>(device.allocate_gpu_memory(size, Pal::GpuHeap::GpuHeapGartUswc));
+}
+
+void* PALPlatform::alloc_unified(DeviceId dev, int64_t size) {
+    auto& device = devices_[dev];
+    return reinterpret_cast<void*>(device.allocate_shared_virtual_memory(size));
+}
+
+void* PALPlatform::alloc_upload(DeviceId dev, int64_t size) {
+    auto& device = devices_[dev];
+    return reinterpret_cast<void*>(device.allocate_gpu_memory(size, Pal::GpuHeap::GpuHeapLocal));
+}
+
+void PALPlatform::release(DeviceId dev, void* ptr) {
+    auto& device = devices_[dev];
+    device.release_gpu_memory(ptr);
+}
+
+void PALPlatform::release_host(DeviceId, void* ptr) {
+    if (ptr == nullptr) {
+        assert(false);
+        return;
+    }
+
+    Pal::IGpuMemory* memory = static_cast<Pal::IGpuMemory*>(ptr);
+    memory->Destroy();
+    free(memory);
+}
+
+void PALPlatform::launch_kernel(DeviceId dev, const LaunchParams& launch_params) {
+    Pal::IPipeline* pipeline = load_kernel(dev, launch_params.file_name, launch_params.kernel_name);
+
+    Pal::CmdBufferBuildInfo cmd_buffer_build_info = {};
+    cmd_buffer_build_info.flags.optimizeExclusiveSubmit = 1;
+
+    Pal::PipelineBindParams params = {};
+    params.pipelineBindPoint = Pal::PipelineBindPoint::Compute;
+    params.pPipeline = pipeline;
+
+    constexpr Pal::HwPipePoint pipe_point = Pal::HwPipePostCs;
+    Pal::BarrierInfo barrier_info = {};
+    barrier_info.waitPoint = Pal::HwPipePostCs;
+    barrier_info.pipePointWaitCount = 1;
+    barrier_info.pPipePoints = &pipe_point;
+    barrier_info.globalSrcCacheMask = Pal::CoherShader;
+    barrier_info.globalDstCacheMask = Pal::CoherShader;
+
+    auto& device = devices_[dev];
+    device.dispatch(cmd_buffer_build_info, params, barrier_info, launch_params);
+}
+
+void PALPlatform::synchronize(DeviceId dev) {
+    Pal::Result result = devices_[dev].queue_->WaitIdle();
+    CHECK_PAL(result, "WaitIdle()");
+}
+
+void PALPlatform::copy(DeviceId dev_src, const void* src, int64_t offset_src, DeviceId dev_dst, void* dst,
+    int64_t offset_dst, int64_t size) {
+    // TODO: Implement inter device copy.
+    assert(dev_src == dev_dst);
+
+    PalDevice& device = devices_[dev_src];
+
+    // Define region to be copied from src to dst.
+    Pal::MemoryCopyRegion copy_region = {};
+    copy_region.srcOffset = offset_src;
+    copy_region.dstOffset = offset_dst;
+    copy_region.copySize = size;
+
+    device.copy_gpu_data(src, dst, copy_region);
+}
+
+void PALPlatform::copy_from_host(
+    const void* src, int64_t offset_src, DeviceId dev_dst, void* dst, int64_t offset_dst, int64_t size) {
+    Pal::IGpuMemory* dst_memory = devices_[dev_dst].get_memory_object(dst);
+
+    // Query if GPU memory is host visible.
+    const Pal::GpuMemoryDesc& dst_memory_desc = dst_memory->Desc();
+    for (Pal::uint32 i = 0; i < dst_memory_desc.heapCount; ++i) {
+        if (dst_memory_desc.heaps[i] == Pal::GpuHeap::GpuHeapInvisible) {
+            // Create a temporary CPU-visible buffer on the GPU.
+            // Upload the data from the host and then copy into the given GPU destination buffer.
+            void* virtual_gpu_address = alloc_upload(dev_dst, size);
+            Pal::IGpuMemory* intermediate_mem = devices_[dev_dst].get_memory_object(virtual_gpu_address);
+            pal_utils::write_to_memory(
+                intermediate_mem, 0, static_cast<const uint8_t*>(src) + offset_src, size);
+
+            copy(dev_dst, virtual_gpu_address, 0, dev_dst, dst, offset_dst, size);
+            release(dev_dst, virtual_gpu_address);
+            return;
+        }
+    }
+
+    pal_utils::write_to_memory(dst_memory, offset_dst, static_cast<const uint8_t*>(src) + offset_src, size);
+}
+
+void PALPlatform::copy_to_host(
+    DeviceId dev_src, const void* src, int64_t offset_src, void* dst, int64_t offset_dst, int64_t size) {
+    Pal::IGpuMemory* src_memory = devices_[dev_src].get_memory_object(src);
+
+    // Query if GPU memory is host visible.
+    const Pal::GpuMemoryDesc& src_memory_desc = src_memory->Desc();
+    for (Pal::uint32 i = 0; i < src_memory_desc.heapCount; ++i) {
+        if (src_memory_desc.heaps[i] == Pal::GpuHeap::GpuHeapInvisible) {
+            // Create a temporary CPU-visible buffer on the GPU and copy the GPU only data into the
+            // CPU-visible buffer, then memcpy the data to the host destination space.
+            void* virtual_gpu_address = alloc_upload(dev_src, size);
+            copy(dev_src, src, offset_src, dev_src, virtual_gpu_address, 0, size);
+
+            Pal::IGpuMemory* intermediate_mem = devices_[dev_src].get_memory_object(virtual_gpu_address);
+            pal_utils::read_from_memory(static_cast<uint8_t*>(dst) + offset_dst, intermediate_mem, 0, size);
+            release(dev_src, virtual_gpu_address);
+            return;
+        }
+    }
+
+    pal_utils::read_from_memory(static_cast<uint8_t*>(dst) + offset_dst, src_memory, offset_src, size);
+}
+
+Pal::IPipeline* PALPlatform::load_kernel(DeviceId dev, const std::string& filename, const std::string& kernelname) {
+    auto& pal_dev = devices_[dev];
+    pal_dev.lock();
+
+    Pal::IPipeline* pipeline = nullptr;
+    auto canonical = std::filesystem::weakly_canonical(filename);
+    auto& prog_cache = pal_dev.programs_;
+
+    // Files can contain multiple kernels, but PAL only accepts a single kernel per pipeline
+    // and that kernel must have a fixed name.
+    // Therefore, we use the anydsl kernelname for our prog_cache and make sure to rename only that function
+    // during jit compilation.
+    const std::string kernel_id = canonical.string() + "_" + kernelname;
+    if (auto prog_it = prog_cache.find(kernel_id); prog_it == prog_cache.end()) {
+        pal_dev.unlock();
+
+        if (canonical.extension() != ".gcn" && canonical.extension() != ".amdgpu")
+            error("Incorrect extension for kernel file '%' (should be '.gcn')", canonical.string());
+
+        // Load file from disk or cache.
+        const std::string src_code = runtime_->load_file(canonical.string());
+
+        pal_utils::ShaderSrc shader_src = pal_utils::ShaderSrc(canonical, src_code, kernelname);
+
+        // Use elf from file or load it from cache.
+        // Important: add kernelname to key to make sure each kernel gets a separate cached file.
+        const auto cache_key = devices_[dev].isa + src_code + kernelname;
+        std::string gcn = canonical.extension() == ".gcn"
+                              ? src_code
+                              : runtime_->load_from_cache(cache_key);
+        if (gcn.empty()) {
+            // Was not an elf file or could not be loaded from cache. Compile source code.
+            if (canonical.extension() == ".amdgpu") {
+                gcn = compile_gcn(dev, std::move(shader_src));
+            }
+            // Cache elf.
+            runtime_->store_to_cache(cache_key, gcn);
+        }
+
+        pipeline = pal_dev.create_pipeline(static_cast<const void*>(gcn.data()), gcn.size());
+
+        pal_dev.lock();
+        prog_cache[kernel_id] = pipeline;
+
+    } else {
+        pipeline = prog_it->second;
+    }
+
+    pal_dev.unlock();
+
+    return pipeline;
+}
+
+// Extracts the work group size from the thorin metadata.
+std::array<uint64_t, 3> extract_thread_group_dims(const pal_utils::ShaderSrc& shader_src) {
+    const char* metadata_key = "reqd_work_group_size";
+    std::array<uint64_t, 3> tg_dims;
+    assert(shader_src.function->getMetadata(metadata_key)->getNumOperands() == 3 && "Work group size malformed.");
+
+    tg_dims[0] = pal_utils::get_metadata_uint(shader_src.function, metadata_key, 0);
+    tg_dims[1] = pal_utils::get_metadata_uint(shader_src.function, metadata_key, 1);
+    tg_dims[2] = pal_utils::get_metadata_uint(shader_src.function, metadata_key, 2);
+    return tg_dims;
+}
+
+#ifdef AnyDSL_runtime_HAS_LLVM_SUPPORT
+#ifndef AnyDSL_runtime_PAL_BITCODE_PATH
+#define AnyDSL_runtime_PAL_BITCODE_PATH "rocm-device-libs/build/amdgcn/bitcode/"
+#endif
+#ifndef AnyDSL_runtime_PAL_BITCODE_SUFFIX
+#define AnyDSL_runtime_PAL_BITCODE_SUFFIX ".bc"
+#endif
+bool llvm_amdgpu_pal_initialized = false;
+std::string PALPlatform::emit_gcn(pal_utils::ShaderSrc&& shader_src, const std::string& cpu,
+    Pal::GfxIpLevel gfx_level, llvm::OptimizationLevel opt) const {
+    if (!llvm_amdgpu_pal_initialized) {
+        llvm_utils::initialize_amdgpu({"gcn"});
+        llvm_amdgpu_pal_initialized = true;
+    }
+
+    std::unique_ptr<llvm::TargetMachine> machine =
+        llvm_utils::create_target_machine(shader_src.llvm_module->getTargetTriple(), cpu);
+
+    // Override data layout with the one coming from the target machine.
+    shader_src.llvm_module->setDataLayout(machine->createDataLayout());
+
+    std::array<uint64_t, 3> tg_dims = extract_thread_group_dims(shader_src);
+
+    if (!shader_src.rename_entry_point())
+        error("Could not find a compute shader entry function in the module!");
+
+    // Set up the MsgPack-encoded metadata PAL expects in shader binaries
+    const uint32_t pal_wavefront_size = 32; // Use fixed wave32 mode
+    llvm::msgpack::Document document =
+        pal_utils::build_metadata(shader_src, gfx_level, tg_dims, pal_wavefront_size);
+
+    // Write the MsgPack document into an LLVM-IR metadata node in this specific way
+    // because that's what the AMDGPU backend expects.
+    std::string blob;
+    document.writeToBlob(blob);
+    llvm::MDString* abiMetaString = llvm::MDString::get(shader_src.llvm_module->getContext(), blob);
+    llvm::MDNode* abiMetaNode = llvm::MDNode::get(shader_src.llvm_module->getContext(), abiMetaString);
+    llvm::NamedMDNode* namedMeta = shader_src.llvm_module->getOrInsertNamedMetadata("amdgpu.pal.metadata.msgpack");
+
+    if (namedMeta->getNumOperands() == 0) {
+        namedMeta->addOperand(abiMetaNode);
+    } else {
+        // If the PAL metadata was already written, then we need to replace the previous value.
+        assert(namedMeta->getNumOperands() == 1);
+        namedMeta->setOperand(0, abiMetaNode);
+    }
+
+    // link ocml.amdgcn and ocml config
+    llvm::Linker linker(*shader_src.llvm_module.get());
+    if (cpu.compare(0, 3, "gfx"))
+        error("Expected gfx ISA, got %", cpu);
+    std::string isa_version = std::string(&cpu[3]);
+    std::string wavefrontsize64 = std::stoi(isa_version) >= 1000 ? "0" : "1";
+
+    std::string ocml_config = R"(; Module anydsl ocml config
+                                @__oclc_finite_only_opt = addrspace(4) constant i8 0
+                                @__oclc_unsafe_math_opt = addrspace(4) constant i8 0
+                                @__oclc_daz_opt = addrspace(4) constant i8 0
+                                @__oclc_correctly_rounded_sqrt32 = addrspace(4) constant i8 0
+                                @__oclc_wavefrontsize64 = addrspace(4) constant i8 )"
+                              + wavefrontsize64;
+    llvm_utils::add_module(linker, llvm::MemoryBuffer::getMemBuffer(ocml_config)->getMemBufferRef(),
+        machine->createDataLayout(), shader_src.llvm_context, llvm::Linker::Flags::None, "ocml config");
+
+    std::string bitcode_path(AnyDSL_runtime_PAL_BITCODE_PATH);
+    std::string bitcode_suffix(AnyDSL_runtime_PAL_BITCODE_SUFFIX);
+
+    std::string ocml_file = bitcode_path + "ocml.ll";
+    llvm_utils::add_module(linker, ocml_file, machine->createDataLayout(), shader_src.llvm_context, llvm::Linker::Flags::LinkOnlyNeeded);
+
+    std::string ockl_file = bitcode_path + "ockl" + bitcode_suffix;
+    llvm_utils::add_module(linker, ockl_file, machine->createDataLayout(), shader_src.llvm_context, llvm::Linker::Flags::LinkOnlyNeeded);
+
+    std::string isa_file = bitcode_path + "oclc_isa_version_" + isa_version + bitcode_suffix;
+    llvm_utils::add_module(linker, isa_file, machine->createDataLayout(), shader_src.llvm_context, llvm::Linker::Flags::LinkOnlyNeeded);
+
+    auto run_pass_manager = [&](std::unique_ptr<llvm::Module> module, llvm::CodeGenFileType cogen_file_type,
+                                std::string out_filename, bool print_ir = false) {
+        machine->Options.MCOptions.AsmVerbose = true;
+
+        llvm::LoopAnalysisManager LAM;
+        llvm::FunctionAnalysisManager FAM;
+        llvm::CGSCCAnalysisManager CGAM;
+        llvm::ModuleAnalysisManager MAM;
+
+        llvm::PassBuilder PB(machine.get());
+
+        PB.registerModuleAnalyses(MAM);
+        PB.registerCGSCCAnalyses(CGAM);
+        PB.registerFunctionAnalyses(FAM);
+        PB.registerLoopAnalyses(LAM);
+        PB.crossRegisterProxies(LAM, FAM, CGAM, MAM);
+
+        PB.registerVectorizerStartEPCallback([](llvm::FunctionPassManager& FPM, llvm::OptimizationLevel) {
+            FPM.addPass(PalPlatformLowerKernelArgumentsPass());
+            FPM.addPass(PalPlatformInsertHaltPass());
+        });
+        PB.registerPipelineEarlySimplificationEPCallback(
+            [gfx_level, tg_dims](llvm::ModulePassManager& MPM, llvm::OptimizationLevel) {
+                MPM.addPass(PalPlatformLowerBuiltinsPass(gfx_level, tg_dims));
+                MPM.addPass(llvm::GlobalDCEPass());
+            });
+
+        // Late insertion to change calling convention of all calls so that the AMDGPU backend doesn't complain
+        PB.registerOptimizerLastEPCallback([](llvm::ModulePassManager& MPM, llvm::OptimizationLevel) {
+            MPM.addPass(PalPlatformFixCallingConventionPass());
+        });
+
+        llvm::ModulePassManager MPM = PB.buildPerModuleDefaultPipeline(opt);
+
+        MPM.run(*module, MAM);
+
+        llvm::legacy::PassManager module_pass_manager;
+        llvm::SmallString<0> outstr;
+        llvm::raw_svector_ostream llvm_stream(outstr);
+
+        machine->addPassesToEmitFile(module_pass_manager, llvm_stream, nullptr, cogen_file_type, true);
+        module_pass_manager.run(*module);
+
+        if (print_ir) {
+            std::error_code EC;
+            llvm::raw_fd_ostream outstream(shader_src.filename + "_final.ll", EC);
+            module->print(outstream, nullptr);
+        }
+
+        std::string out(outstr.begin(), outstr.end());
+        runtime_->store_file(out_filename, out);
+    };
+
+    std::string asm_file = shader_src.filename + "_" + shader_src.kernelname + ".asm";
+    std::string obj_file = shader_src.filename + ".obj";
+
+    bool print_ir = true;
+    if (print_ir)
+        run_pass_manager(llvm::CloneModule(*shader_src.llvm_module.get()), llvm::CodeGenFileType::CGFT_AssemblyFile,
+            asm_file, print_ir);
+    run_pass_manager(std::move(shader_src.llvm_module), llvm::CodeGenFileType::CGFT_ObjectFile, obj_file);
+
+    return runtime_->load_file(obj_file);
+}
+#else
+std::string PALPlatform::emit_gcn(
+    const std::string&, const std::string&, Pal::GfxIpLevel, const std::string&, int) const {
+    error("Recompile runtime with LLVM enabled for gcn support.");
+}
+#endif
+
+std::string PALPlatform::compile_gcn(DeviceId dev, pal_utils::ShaderSrc&& shader_src) const {
+    debug("Compiling AMDGPU to GCN using amdgpu for kernel '%' in file '%' on PAL device %", shader_src.kernelname,
+        shader_src.filename, dev);
+    const auto& device = devices_[dev];
+    return emit_gcn(std::move(shader_src), device.isa, device.gfx_level, llvm::OptimizationLevel::O3);
+}
+
+const char* PALPlatform::device_name(DeviceId dev) const { return devices_[dev].name.c_str(); }
+
+void register_pal_platform(Runtime* runtime) { runtime->register_platform<PALPlatform>(); }

--- a/src/pal_platform.cpp
+++ b/src/pal_platform.cpp
@@ -151,7 +151,7 @@ PALPlatform::PALPlatform(Runtime* runtime)
             }
         }
 
-        devices_.emplace_back(pal_devices[i]);
+        devices_.emplace_back(pal_devices[i], runtime);
     }
 }
 

--- a/src/pal_platform.h
+++ b/src/pal_platform.h
@@ -1,0 +1,96 @@
+// Copyright (c) 2023 Advanced Micro Devices, Inc. All rights reserved.
+
+#ifndef PAL_PLATFORM_H
+#define PAL_PLATFORM_H
+
+#include "pal/pal_device.h"
+#include "pal/pal_utils.h"
+#include "platform.h"
+#include "runtime.h"
+
+#include <atomic>
+#include <functional>
+#include <string>
+#include <unordered_map>
+#include <vector>
+
+#include <pal.h>
+#include <palLib.h>
+#include <palPipeline.h>
+#include <palPlatform.h>
+#include <palQueue.h>
+
+#ifdef AnyDSL_runtime_HAS_LLVM_SUPPORT
+#include <llvm/IR/DataLayout.h>
+#include <llvm/IR/LLVMContext.h>
+#include <llvm/Linker/Linker.h>
+#include <llvm/Pass.h>
+#include <llvm/Passes/OptimizationLevel.h>
+#include <llvm/Support/SourceMgr.h>
+#include <llvm/Target/TargetMachine.h>
+#endif
+
+namespace llvm_utils {
+
+// Initializes llvm with amdgpu using the following commandline options:
+// ANYDSL_LLVM_ARGS="-<custom_llvm_args> -amdgpu-sroa -amdgpu-load-store-vectorizer
+// -amdgpu-scalarize-global-loads -amdgpu-internalize-symbols
+// -amdgpu-early-inline-all -amdgpu-sdwa-peephole -amdgpu-dpp-combine
+// -enable-amdgpu-aa -amdgpu-late-structurize=0 -amdgpu-function-calls
+// -amdgpu-simplify-libcall -amdgpu-ir-lower-kernel-arguments
+// -amdgpu-atomic-optimizations -amdgpu-mode-register"
+void initialize_amdgpu(std::vector<std::string> custom_llvm_args);
+
+std::unique_ptr<llvm::TargetMachine> create_target_machine(const std::string& target_triple, const std::string& cpu);
+
+// Creates a module, sets its data layout and links it to the base_module.
+void add_module(llvm::Linker& base_module, const std::string& module_file_path, const llvm::DataLayout& machine_data_layout,
+    llvm::LLVMContext& llvm_context, llvm::Linker::Flags flags);
+
+// Creates a module, sets its data layout and links it to the base_module.
+void add_module(llvm::Linker& base_module, const llvm::MemoryBufferRef& module_data_ref, const llvm::DataLayout& machine_data_layout,
+    llvm::LLVMContext& llvm_context, llvm::Linker::Flags flags, const char* module_name);
+
+} // namespace llvm_utils
+
+class PALPlatform : public Platform {
+public:
+    PALPlatform(Runtime* runtime);
+    ~PALPlatform();
+
+protected:
+    void* alloc(DeviceId dev, int64_t size) override;
+    void* alloc_host(DeviceId dev, int64_t size) override;
+    void* alloc_unified(DeviceId dev, int64_t size) override;
+    void* alloc_upload(DeviceId dev, int64_t size);
+    void* get_device_ptr(DeviceId, void*) override { command_unavailable("get_device_ptr"); }
+    void release(DeviceId dev, void* ptr) override;
+    void release_host(DeviceId dev, void* ptr) override;
+
+    void launch_kernel(DeviceId dev, const LaunchParams& launch_params) override;
+
+    void synchronize(DeviceId dev) override;
+
+    void copy(DeviceId, const void* src, int64_t offset_src, DeviceId, void* dst, int64_t offset_dst,
+        int64_t size) override;
+    void copy_from_host(
+        const void* src, int64_t offset_src, DeviceId, void* dst, int64_t offset_dst, int64_t size) override;
+    void copy_to_host(
+        DeviceId, const void* src, int64_t offset_src, void* dst, int64_t offset_dst, int64_t size) override;
+
+    size_t dev_count() const override { return devices_.size(); }
+    std::string name() const override { return "PAL"; }
+    const char* device_name(DeviceId dev) const override;
+    bool device_check_feature_support(DeviceId, const char*) const override { return false; }
+
+    Pal::IPipeline* load_kernel(DeviceId dev, const std::string& filename, const std::string& kernelname);
+    std::string compile_gcn(DeviceId dev, pal_utils::ShaderSrc&& shader_src) const;
+    std::string emit_gcn(pal_utils::ShaderSrc&& shader_src, const std::string& cpu,
+        Pal::GfxIpLevel gfx_level, llvm::OptimizationLevel opt) const;
+
+protected:
+    Pal::IPlatform* platform_;
+    std::vector<PalDevice> devices_;
+};
+
+#endif

--- a/src/pal_platform.h
+++ b/src/pal_platform.h
@@ -62,7 +62,6 @@ protected:
     void* alloc(DeviceId dev, int64_t size) override;
     void* alloc_host(DeviceId dev, int64_t size) override;
     void* alloc_unified(DeviceId dev, int64_t size) override;
-    void* alloc_upload(DeviceId dev, int64_t size);
     void* get_device_ptr(DeviceId, void*) override { command_unavailable("get_device_ptr"); }
     void release(DeviceId dev, void* ptr) override;
     void release_host(DeviceId dev, void* ptr) override;

--- a/src/pal_platform.h
+++ b/src/pal_platform.h
@@ -1,5 +1,3 @@
-// Copyright (c) 2023 Advanced Micro Devices, Inc. All rights reserved.
-
 #ifndef PAL_PLATFORM_H
 #define PAL_PLATFORM_H
 

--- a/src/pal_platform.h
+++ b/src/pal_platform.h
@@ -21,37 +21,8 @@
 #include <palQueue.h>
 
 #ifdef AnyDSL_runtime_HAS_LLVM_SUPPORT
-#include <llvm/IR/DataLayout.h>
-#include <llvm/IR/LLVMContext.h>
-#include <llvm/Linker/Linker.h>
-#include <llvm/Pass.h>
 #include <llvm/Passes/OptimizationLevel.h>
-#include <llvm/Support/SourceMgr.h>
-#include <llvm/Target/TargetMachine.h>
 #endif
-
-namespace llvm_utils {
-
-// Initializes llvm with amdgpu using the following commandline options:
-// ANYDSL_LLVM_ARGS="-<custom_llvm_args> -amdgpu-sroa -amdgpu-load-store-vectorizer
-// -amdgpu-scalarize-global-loads -amdgpu-internalize-symbols
-// -amdgpu-early-inline-all -amdgpu-sdwa-peephole -amdgpu-dpp-combine
-// -enable-amdgpu-aa -amdgpu-late-structurize=0 -amdgpu-function-calls
-// -amdgpu-simplify-libcall -amdgpu-ir-lower-kernel-arguments
-// -amdgpu-atomic-optimizations -amdgpu-mode-register"
-void initialize_amdgpu(std::vector<std::string> custom_llvm_args);
-
-std::unique_ptr<llvm::TargetMachine> create_target_machine(const std::string& target_triple, const std::string& cpu);
-
-// Creates a module, sets its data layout and links it to the base_module.
-void add_module(llvm::Linker& base_module, const std::string& module_file_path, const llvm::DataLayout& machine_data_layout,
-    llvm::LLVMContext& llvm_context, llvm::Linker::Flags flags);
-
-// Creates a module, sets its data layout and links it to the base_module.
-void add_module(llvm::Linker& base_module, const llvm::MemoryBufferRef& module_data_ref, const llvm::DataLayout& machine_data_layout,
-    llvm::LLVMContext& llvm_context, llvm::Linker::Flags flags, const char* module_name);
-
-} // namespace llvm_utils
 
 class PALPlatform : public Platform {
 public:

--- a/src/platform.h
+++ b/src/platform.h
@@ -12,6 +12,7 @@ void register_cpu_platform(Runtime*);
 void register_cuda_platform(Runtime*);
 void register_opencl_platform(Runtime*);
 void register_hsa_platform(Runtime*);
+void register_pal_platform(Runtime*);
 
 /// A runtime platform. Exposes a set of devices, a copy function,
 /// and functions to allocate and release memory.

--- a/src/runtime.cpp
+++ b/src/runtime.cpp
@@ -17,6 +17,9 @@ void register_opencl_platform(Runtime* runtime) { runtime->register_platform<Dum
 #ifndef AnyDSL_runtime_HAS_HSA_SUPPORT
 void register_hsa_platform(Runtime* runtime) { runtime->register_platform<DummyPlatform>("HSA"); }
 #endif
+#ifndef AnyDSL_runtime_HAS_PAL_SUPPORT
+void register_pal_platform(Runtime* runtime) { runtime->register_platform<DummyPlatform>("PAL"); }
+#endif
 
 Runtime::Runtime(std::pair<ProfileLevel, ProfileLevel> profile)
     : profile_(profile)

--- a/src/runtime.h
+++ b/src/runtime.h
@@ -21,19 +21,21 @@ class Platform;
 
 enum class KernelArgType : uint8_t { Val = 0, Ptr, Struct };
 
+struct ParamsArgs {
+    void** data;
+    const uint32_t* sizes;
+    const uint32_t* aligns;
+    const uint32_t* alloc_sizes;
+    const KernelArgType* types;
+};
+
 /// The parameters to a `anydsl_launch_kernel()` call.
 struct LaunchParams {
     const char* file_name;
     const char* kernel_name;
     const uint32_t* grid;
     const uint32_t* block;
-    struct {
-        void** data;
-        const uint32_t* sizes;
-        const uint32_t* aligns;
-        const uint32_t* alloc_sizes;
-        const KernelArgType* types;
-    } args;
+    ParamsArgs args;
     uint32_t num_args;
 };
 


### PR DESCRIPTION
This adds the necessary AnyDSL runtime code to interface with AMD GPUs through the PAL driver library. This poses an alternative to the HSA (ROCm) based support for AMD GPUs currently available in AnyDSL.

Depends on AnyDSL/thorin#154 in thorin and AnyDSL/anydsl#17 in the metaproject.

This PR includes work by Richard Membarth (@richardmembarth) and Felix Kawala (@FelixKawala).