### PR TITLE
Add env variable for libdevice

### DIFF
--- a/src/cuda_platform.cpp
+++ b/src/cuda_platform.cpp
@@ -36,6 +36,8 @@ using namespace std::literals;
 #define CHECK_NVRTC(err, name) check_nvrtc_errors (err, name, __FILE__, __LINE__)
 #define CHECK_CUDA(err, name)  check_cuda_errors  (err, name, __FILE__, __LINE__)
 
+#define ANYDSL_CUDA_LIBDEVICE_PATH_ENV "ANYDSL_CUDA_LIBDEVICE_PATH"
+
 inline void check_cuda_errors(CUresult err, const char* name, const char* file, const int line) {
     if (CUDA_SUCCESS != err) {
         const char* error_name;
@@ -402,9 +404,13 @@ static std::string emit_nvptx(const std::string& program, const std::string& cpu
     llvm::TargetMachine* machine = target->createTargetMachine(triple_str, cpu, "" /* attrs */, options, llvm::Reloc::PIC_, llvm::CodeModel::Small, llvm::CodeGenOpt::Aggressive);
 
     // link libdevice
-    std::unique_ptr<llvm::Module> libdevice_module(llvm::parseIRFile(AnyDSL_runtime_LIBDEVICE_LIB, diagnostic_err, llvm_context));
+    const char* env_libdevice_path = std::getenv(ANYDSL_CUDA_LIBDEVICE_PATH_ENV);
+    if (!env_libdevice_path)
+        env_libdevice_path = AnyDSL_runtime_LIBDEVICE_LIB;
+
+    std::unique_ptr<llvm::Module> libdevice_module(llvm::parseIRFile(env_libdevice_path, diagnostic_err, llvm_context));
     if (libdevice_module == nullptr)
-        error("Can't create libdevice module for '%'", AnyDSL_runtime_LIBDEVICE_LIB);
+        error("Can't create libdevice module for '%'", env_libdevice_path);
 
     // override data layout with the one coming from the target machine
     llvm_module->setDataLayout(machine->createDataLayout());


### PR DESCRIPTION
Add new environment variable `ANYDSL_CUDA_LIBDEVICE_PATH` to specify the location of the `libdevice.bc` file. 

If not specified the default one determined during cmake config will be used (so no change in behavior for old code).

This PR is necessary to make deployment of software work!