### PR TITLE
Use CUDA primary device context instead of creating our own context

### DIFF
--- a/src/cuda_platform.cpp
+++ b/src/cuda_platform.cpp
@@ -110,8 +110,8 @@ CudaPlatform::CudaPlatform(Runtime* runtime)
         devices_[i].compute_capability = (CUjit_target)(major * 10 + minor);
         debug("  (%) %, Compute capability: %.%", i, name, major, minor);
 
-        err = cuCtxCreate(&devices_[i].ctx, CU_CTX_MAP_HOST, devices_[i].dev);
-        CHECK_CUDA(err, "cuCtxCreate()");
+        err = cuDevicePrimaryCtxRetain(&devices_[i].ctx, devices_[i].dev);
+        CHECK_CUDA(err, "cuDevicePrimaryCtxRetain()");
     }
 }
 
@@ -139,7 +139,7 @@ void CudaPlatform::erase_profiles(bool erase_all) {
 CudaPlatform::~CudaPlatform() {
     erase_profiles(true);
     for (size_t i = 0; i < devices_.size(); i++)
-        cuCtxDestroy(devices_[i].ctx);
+        cuDevicePrimaryCtxRelease(devices_[i].dev);
 }
 
 void* CudaPlatform::alloc(DeviceId dev, int64_t size) {


### PR DESCRIPTION
By creating our own context, we make interop with external code that also uses CUDA impossible. This change uses the primary context for each GPU instead of creating a separate context.

Note: the `CU_CTX_MAP_HOST` flag is deprecated since CUDA 11 and, [according to documentation](https://docs.nvidia.com/cuda/cuda-driver-api/deprecated.html#deprecated__deprecated_1_deprecated000052), did not serve any purpose since CUDA 3.2, so dropping it should not result in any issues.