### PR TITLE
introduce option()s for backends to easily disable them

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -27,53 +27,58 @@ add_library(runtime_base STATIC
     log.h)
 
 # look for CUDA
+option(AnyDSL_Runtime_ENABLE_CUDA "Support for running CUDA kernels" ON)
 if(${CMAKE_VERSION} VERSION_LESS "3.18.0")
-    find_package(CUDA QUIET)
-    if(CUDA_FOUND)
-        find_library(CUDA_NVVM_LIBRARY nvvm
-            HINTS ${CUDA_TOOLKIT_ROOT_DIR}/nvvm
-            PATH_SUFFIXES lib lib64 lib/x64)
-        find_library(CUDA_NVRTC_LIBRARY nvrtc
-            HINTS ${CUDA_TOOLKIT_ROOT_DIR}
-            PATH_SUFFIXES lib lib64 lib/x64)
-        find_library(CUDA_LIBRARY cuda
-            HINTS ${CUDA_TOOLKIT_ROOT_DIR}
-            PATH_SUFFIXES lib lib64 lib/x64)
-        add_library(runtime_cuda STATIC cuda_platform.cpp cuda_platform.h)
-        target_include_directories(runtime_cuda PRIVATE ${CUDA_INCLUDE_DIRS} "${CUDA_TOOLKIT_ROOT_DIR}/nvvm/include")
-        target_link_libraries(runtime_cuda PRIVATE runtime_base ${CUDA_LIBRARY} ${CUDA_NVVM_LIBRARY} ${CUDA_NVRTC_LIBRARY})
-        list(APPEND RUNTIME_PLATFORMS runtime_cuda)
-        # TODO: would be nice to reference directly the file
-        find_file(AnyDSL_runtime_LIBDEVICE_LIB
-            NAMES libdevice.10.bc
-            HINTS ${CUDA_TOOLKIT_ROOT_DIR}
-            PATH_SUFFIXES nvvm/libdevice)
-        set(AnyDSL_runtime_NVCC_INC ${CUDA_INCLUDE_DIRS})
-        mark_as_advanced(AnyDSL_runtime_LIBDEVICE_DIR AnyDSL_runtime_NVCC_INC)
+    if(AnyDSL_Runtime_ENABLE_CUDA)
+        find_package(CUDA)
+        if(CUDA_FOUND)
+            find_library(CUDA_NVVM_LIBRARY nvvm
+                HINTS ${CUDA_TOOLKIT_ROOT_DIR}/nvvm
+                PATH_SUFFIXES lib lib64 lib/x64)
+            find_library(CUDA_NVRTC_LIBRARY nvrtc
+                HINTS ${CUDA_TOOLKIT_ROOT_DIR}
+                PATH_SUFFIXES lib lib64 lib/x64)
+            find_library(CUDA_LIBRARY cuda
+                HINTS ${CUDA_TOOLKIT_ROOT_DIR}
+                PATH_SUFFIXES lib lib64 lib/x64)
+            add_library(runtime_cuda STATIC cuda_platform.cpp cuda_platform.h)
+            target_include_directories(runtime_cuda PRIVATE ${CUDA_INCLUDE_DIRS} "${CUDA_TOOLKIT_ROOT_DIR}/nvvm/include")
+            target_link_libraries(runtime_cuda PRIVATE runtime_base ${CUDA_LIBRARY} ${CUDA_NVVM_LIBRARY} ${CUDA_NVRTC_LIBRARY})
+            list(APPEND RUNTIME_PLATFORMS runtime_cuda)
+            # TODO: would be nice to reference directly the file
+            find_file(AnyDSL_runtime_LIBDEVICE_LIB
+                NAMES libdevice.10.bc
+                HINTS ${CUDA_TOOLKIT_ROOT_DIR}
+                PATH_SUFFIXES nvvm/libdevice)
+            set(AnyDSL_runtime_NVCC_INC ${CUDA_INCLUDE_DIRS})
+            mark_as_advanced(AnyDSL_runtime_LIBDEVICE_DIR AnyDSL_runtime_NVCC_INC)
+        endif()
     endif()
     set(AnyDSL_runtime_HAS_CUDA_SUPPORT ${CUDA_FOUND} CACHE INTERNAL "enables CUDA/NVVM support")
 else()
-    find_package(CUDAToolkit QUIET)
-    if(CUDAToolkit_FOUND)
-        # this is more robust in case CUDAToolkit_LIBRARY_ROOT is not defined
-        find_path(CUDAToolkit_LIBRARY_ROOT
-            NAMES version.txt version.json bin/nvcc
-            HINTS ${CUDAToolkit_LIBRARY_ROOT} ${CUDAToolkit_ROOT} ${CUDAToolkit_BIN_DIR}/../)
-        find_library(CUDAToolkit_NVVM_LIBRARY nvvm
-            HINTS ${CUDAToolkit_LIBRARY_ROOT}/nvvm
-            PATH_SUFFIXES lib lib64 lib/x64)
-        add_library(runtime_cuda STATIC cuda_platform.cpp cuda_platform.h)
-        target_include_directories(runtime_cuda PRIVATE "${CUDAToolkit_LIBRARY_ROOT}/nvvm/include")
-        target_link_libraries(runtime_cuda PRIVATE runtime_base CUDA::cuda_driver CUDA::nvrtc ${CUDAToolkit_NVVM_LIBRARY})
-        list(APPEND RUNTIME_PLATFORMS runtime_cuda)
-        # TODO: would be nice to reference directly the file
-        find_file(AnyDSL_runtime_LIBDEVICE_LIB
-            NAMES libdevice.10.bc
-            HINTS ${CUDAToolkit_LIBRARY_ROOT} ${CUDAToolkit_LIBRARY_DIR}
-            PATH_SUFFIXES cuda/nvvm/libdevice nvvm/libdevice
-            REQUIRED)
-        set(AnyDSL_runtime_NVCC_INC ${CUDAToolkit_INCLUDE_DIRS})
-        mark_as_advanced(AnyDSL_runtime_LIBDEVICE_LIB AnyDSL_runtime_NVCC_INC)
+    if(AnyDSL_Runtime_ENABLE_CUDA)
+        find_package(CUDAToolkit)
+        if(CUDAToolkit_FOUND)
+            # this is more robust in case CUDAToolkit_LIBRARY_ROOT is not defined
+            find_path(CUDAToolkit_LIBRARY_ROOT
+                NAMES version.txt version.json bin/nvcc
+                HINTS ${CUDAToolkit_LIBRARY_ROOT} ${CUDAToolkit_ROOT} ${CUDAToolkit_BIN_DIR}/../)
+            find_library(CUDAToolkit_NVVM_LIBRARY nvvm
+                HINTS ${CUDAToolkit_LIBRARY_ROOT}/nvvm
+                PATH_SUFFIXES lib lib64 lib/x64)
+            add_library(runtime_cuda STATIC cuda_platform.cpp cuda_platform.h)
+            target_include_directories(runtime_cuda PRIVATE "${CUDAToolkit_LIBRARY_ROOT}/nvvm/include")
+            target_link_libraries(runtime_cuda PRIVATE runtime_base CUDA::cuda_driver CUDA::nvrtc ${CUDAToolkit_NVVM_LIBRARY})
+            list(APPEND RUNTIME_PLATFORMS runtime_cuda)
+            # TODO: would be nice to reference directly the file
+            find_file(AnyDSL_runtime_LIBDEVICE_LIB
+                NAMES libdevice.10.bc
+                HINTS ${CUDAToolkit_LIBRARY_ROOT} ${CUDAToolkit_LIBRARY_DIR}
+                PATH_SUFFIXES cuda/nvvm/libdevice nvvm/libdevice
+                REQUIRED)
+            set(AnyDSL_runtime_NVCC_INC ${CUDAToolkit_INCLUDE_DIRS})
+            mark_as_advanced(AnyDSL_runtime_LIBDEVICE_LIB AnyDSL_runtime_NVCC_INC)
+        endif()
     endif()
     set(AnyDSL_runtime_HAS_CUDA_SUPPORT ${CUDAToolkit_FOUND} CACHE INTERNAL "enables CUDA/NVVM support")
 endif()
@@ -82,63 +87,72 @@ if(AnyDSL_runtime_HAS_CUDA_SUPPORT)
     set(AnyDSL_runtime_CUDA_CXX_STANDARD 11 CACHE STRING "C++ version to use for CUDA code")
 endif()
 
-# look for OpenCL
-find_package(OpenCL)
-if(OpenCL_FOUND)
-    add_library(runtime_opencl STATIC opencl_platform.cpp opencl_platform.h)
-    target_link_libraries(runtime_opencl PRIVATE runtime_base OpenCL::OpenCL)
-    list(APPEND RUNTIME_PLATFORMS runtime_opencl)
+option(AnyDSL_Runtime_ENABLE_OPENCL "Support for running OpenCL kernels" ON)
+if(AnyDSL_Runtime_ENABLE_OPENCL)
+    # look for OpenCL
+    find_package(OpenCL)
+    if(OpenCL_FOUND)
+        add_library(runtime_opencl STATIC opencl_platform.cpp opencl_platform.h)
+        target_link_libraries(runtime_opencl PRIVATE runtime_base OpenCL::OpenCL)
+        list(APPEND RUNTIME_PLATFORMS runtime_opencl)
 
-    # look for Xilinx-HLS
-    find_package(XHLS)
-    #if(XHLS_FOUND)
-    #    target_include_directories(runtime_opencl PRIVATE ${Xilinx_INCLUDE_DIRS})
-    #endif()
+        # look for Xilinx-HLS
+        find_package(XHLS)
+        #if(XHLS_FOUND)
+        #    target_include_directories(runtime_opencl PRIVATE ${Xilinx_INCLUDE_DIRS})
+        #endif()
+    endif()
 endif()
 set(AnyDSL_runtime_HAS_OPENCL_SUPPORT ${OpenCL_FOUND} CACHE INTERNAL "enables OpenCL support")
 
-# look for HSA
-find_package(hsa-runtime64 PATHS /opt/rocm)
-if(hsa-runtime64_FOUND)
-    add_library(runtime_hsa STATIC hsa_platform.cpp hsa_platform.h)
-    target_link_libraries(runtime_hsa PRIVATE runtime_base hsa-runtime64::hsa-runtime64)
-    list(APPEND RUNTIME_PLATFORMS runtime_hsa)
+option(AnyDSL_Runtime_ENABLE_HSA "Support for running kernels on AMD's HSA/ROCm compute stack" ON)
+if(AnyDSL_Runtime_ENABLE_HSA)
+    # look for HSA
+    find_package(hsa-runtime64 PATHS /opt/rocm)
+    if(hsa-runtime64_FOUND)
+        add_library(runtime_hsa STATIC hsa_platform.cpp hsa_platform.h)
+        target_link_libraries(runtime_hsa PRIVATE runtime_base hsa-runtime64::hsa-runtime64)
+        list(APPEND RUNTIME_PLATFORMS runtime_hsa)
 
-    find_package(AMDDeviceLibs PATHS /opt/rocm)
-    get_target_property(ocml_LOCATION ocml LOCATION)
-    get_filename_component(AnyDSL_runtime_HSA_BITCODE_PATH ${ocml_LOCATION} DIRECTORY)
-    get_filename_component(AnyDSL_runtime_HSA_BITCODE_SUFFIX ${ocml_LOCATION} EXT)
+        find_package(AMDDeviceLibs PATHS /opt/rocm)
+        get_target_property(ocml_LOCATION ocml LOCATION)
+        get_filename_component(AnyDSL_runtime_HSA_BITCODE_PATH ${ocml_LOCATION} DIRECTORY)
+        get_filename_component(AnyDSL_runtime_HSA_BITCODE_SUFFIX ${ocml_LOCATION} EXT)
+    endif()
 endif()
 set(AnyDSL_runtime_HAS_HSA_SUPPORT ${hsa-runtime64_FOUND} CACHE INTERNAL "enables HSA support")
 
-# look for PAL
-find_package(pal)
-if(pal_FOUND)
-    add_library(runtime_pal STATIC 
-        pal_platform.h
-        pal_platform.cpp
-        pal/pal_lower_kernel_arguments_pass.h
-        pal/pal_lower_kernel_arguments_pass.cpp
-        pal/pal_fix_calling_convention_pass.h
-        pal/pal_fix_calling_convention_pass.cpp
-        pal/pal_lower_builtins_pass.h
-        pal/pal_lower_builtins_pass.cpp
-        pal/pal_insert_halt_pass.h
-        pal/pal_insert_halt_pass.cpp
-        pal/pal_utils.h
-        pal/pal_utils.cpp
-        pal/pal_device.h
-        pal/pal_device.cpp)
-    target_link_libraries(runtime_pal PRIVATE runtime_base pal::pal)
-    list(APPEND RUNTIME_PLATFORMS runtime_pal)
+option(AnyDSL_Runtime_ENABLE_PAL "Support for running kernels through AMD's PAL interface" ON)
+    if(AnyDSL_Runtime_ENABLE_PAL)
+    # look for PAL
+    find_package(pal)
+    if(pal_FOUND)
+        add_library(runtime_pal STATIC
+            pal_platform.h
+            pal_platform.cpp
+            pal/pal_lower_kernel_arguments_pass.h
+            pal/pal_lower_kernel_arguments_pass.cpp
+            pal/pal_fix_calling_convention_pass.h
+            pal/pal_fix_calling_convention_pass.cpp
+            pal/pal_lower_builtins_pass.h
+            pal/pal_lower_builtins_pass.cpp
+            pal/pal_insert_halt_pass.h
+            pal/pal_insert_halt_pass.cpp
+            pal/pal_utils.h
+            pal/pal_utils.cpp
+            pal/pal_device.h
+            pal/pal_device.cpp)
+        target_link_libraries(runtime_pal PRIVATE runtime_base pal::pal)
+        list(APPEND RUNTIME_PLATFORMS runtime_pal)
 
-    find_file(AnyDSL_runtime_ROCM_OCML_LIB
-        NAMES ocml.bc
-        HINTS ${CMAKE_SOURCE_DIR}/../rocm-device-libs
-        PATH_SUFFIXES build/amdgcn/bitcode
-        REQUIRED)
-    get_filename_component(AnyDSL_runtime_PAL_BITCODE_PATH ${AnyDSL_runtime_ROCM_OCML_LIB} DIRECTORY)
-    get_filename_component(AnyDSL_runtime_PAL_BITCODE_SUFFIX ${AnyDSL_runtime_ROCM_OCML_LIB} EXT)
+        find_file(AnyDSL_runtime_ROCM_OCML_LIB
+            NAMES ocml.bc
+            HINTS ${CMAKE_SOURCE_DIR}/../rocm-device-libs
+            PATH_SUFFIXES build/amdgcn/bitcode
+            REQUIRED)
+        get_filename_component(AnyDSL_runtime_PAL_BITCODE_PATH ${AnyDSL_runtime_ROCM_OCML_LIB} DIRECTORY)
+        get_filename_component(AnyDSL_runtime_PAL_BITCODE_SUFFIX ${AnyDSL_runtime_ROCM_OCML_LIB} EXT)
+    endif()
 endif()
 set(AnyDSL_runtime_HAS_PAL_SUPPORT ${pal_FOUND} CACHE INTERNAL "enables PAL support")
 


### PR DESCRIPTION
I've been doing this by hand (editing CMakeLists.txt) for years, but I think we need a proper way to do this: disable backends at will, easily. For various reasons (LLVM linking conflicts, old broken installations for some dependency, buggy backend, ...) this is often required and thus needs to be facilitated.

This arguably also addresses the motivation for https://github.com/AnyDSL/runtime/pull/51 by only attempting to find_package if a given backend is enabled.

Currently this defaults to try to enable all backends, before looking for their dependencies.

Alternatively we could:
 * Fail if a dependency is not meant but the backend is enabled
 * Do find_package first and remove the option if the dependencies aren't met
 * Forcefully disable backends when depdencies aren't met (with `set(... FORCE)`)