### PR TITLE
Prevent crash when `compile` fails in JIT

### DIFF
--- a/src/jit.cpp
+++ b/src/jit.cpp
@@ -68,8 +68,10 @@ struct JIT {
             if (!::compile(
                 { "runtime", module_name },
                 { std::string(runtime_srcs), program_str },
-                thorin.world(), std::cerr))
+                thorin.world(), std::cerr)) {
                 error("JIT: error while compiling sources");
+                return -1;
+            }
 
             thorin.opt();
 

--- a/src/jit.cpp
+++ b/src/jit.cpp
@@ -69,7 +69,7 @@ struct JIT {
                 { "runtime", module_name },
                 { std::string(runtime_srcs), program_str },
                 thorin.world(), std::cerr)) {
-                error("JIT: error while compiling sources");
+                print(std::cerr, "JIT: error while compiling sources");
                 return -1;
             }
 


### PR DESCRIPTION
Simple fix to prevent `thorin.opt()` being called when `::compile` fails due to simple syntax errors and other issues. 
This is mandatory for proper safe guards, error recovery and the simple fact that syntax errors are simple to make :D